### PR TITLE
[feature] Make sure that this package is not dependant from the framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,11 @@
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.5.0 || ^7.0",
-        "laravel/framework": "^7.0 || ^8.0"
+        "illuminate/console": "^7.0 || ^8.0",
+        "illuminate/contracts": "^7.0 || ^8.0",
+        "illuminate/http": "^7.0 || ^8.0",
+        "illuminate/routing": "^7.0 || ^8.0",
+        "illuminate/support": "^7.0 || ^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",


### PR DESCRIPTION
This PR ensures that there is no hard reliance on the Laravel framework.
Instead only some illuminate packages are required.