### PR TITLE
Request with a null value should be correctly masked

### DIFF
--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -195,7 +195,9 @@ class TreblleMiddleware
                                     }
                                 }
                             } else {
-                                $data[$key] = str_repeat('*', strlen($value));
+                                $data[$key] = $value != null
+                                    ? str_repeat('*', strlen($value))
+                                    : $value;
                             }
                         }
                     }

--- a/tests/Middlewares/TreblleMiddlewareTest.php
+++ b/tests/Middlewares/TreblleMiddlewareTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Tests\Middlewares;
+
+use Treblle\Middlewares\TreblleMiddleware;
+use Treblle\Tests\TestCase;
+
+class TreblleMiddlewareTest extends TestCase
+{
+    /**
+     * @var TreblleMiddleware
+     */
+    private $treblleMiddleware;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->treblleMiddleware = new TreblleMiddleware();
+    }
+
+    public function testRequestWithNullValueIsMaskedCorrectly(): void
+    {
+        $requestWithNullField = [
+            'cc' => null,
+            'otherValue' => 'something',
+            'password' => '1234',
+        ];
+
+        $maskedRequest = $this->treblleMiddleware->maskFields($requestWithNullField);
+
+        $this->assertEquals($maskedRequest, [
+            'cc' => null, // Should be left as null value
+            'otherValue' => 'something',
+            'password' => '****', // Should be masked
+        ]);
+    }
+}


### PR DESCRIPTION
Hi! 

We are testing Treblle in our application. We are using Postmark inbound emails webhooks. The request has a `Cc` key in the request. This can be null, i.e. `[Cc => null]`. The Treblle middleware fails when this is the case: the `maskFields($data)` gets called, the `Cc` field is treated as a masked field, but at line 198 fails because of the `strlen` function. 

/vendor/treblle/treblle-laravel/src/Middlewares/TreblleMiddleware.php in strlen at line 198

`$data[$key] = str_repeat('*', strlen($value));`

This pull request tries to solve that by checking if the masked field in question is null. In that case, we left it as it is (no masking).

Let me know your thoughts on this or if I should do something different. Or simply reject the pull! 

Thanks. 

