### PR TITLE
feat: add exception whitelist support

### DIFF
--- a/config/treblle.php
+++ b/config/treblle.php
@@ -31,4 +31,11 @@ return [
         'credit_score',
         'api_key',
     ],
+
+    /**
+     * A list of exception classes that we do not want reported as error on treblle
+     */
+    'ignore_exceptions' => [
+        \Illuminate\Validation\ValidationException::class
+    ],
 ];

--- a/tests/Middlewares/TreblleMiddlewareTest.php
+++ b/tests/Middlewares/TreblleMiddlewareTest.php
@@ -6,6 +6,9 @@ namespace Treblle\Tests\Middlewares;
 
 use Treblle\Middlewares\TreblleMiddleware;
 use Treblle\Tests\TestCase;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\ValidationException;
+use Exception;
 
 class TreblleMiddlewareTest extends TestCase
 {
@@ -36,5 +39,36 @@ class TreblleMiddlewareTest extends TestCase
             'otherValue' => 'something',
             'password' => '****', // Should be masked
         ]);
+    }
+
+    public function testResponseExceptionsAreReportedAsError()
+    {
+        $response = new JsonResponse(['name' => 'treblle']);
+        $response->withException($exception = new Exception('Some exception'));
+
+        $this->treblleMiddleware->prepareResponseData($response);
+
+        $payload = $this->treblleMiddleware->getPayload();
+        $this->assertArrayHasKey('errors', $payload['data']);
+        $this->assertEquals($payload['data']['errors'], [[
+            'source' => 'onException',
+            'type' => 'UNHANDLED_EXCEPTION',
+            'message' => $exception->getMessage(),
+            'file' => $exception->getFile(),
+            'line' => $exception->getLine(),
+        ]]);
+    }
+
+    public function testWhitelistedExceptionsAreNotReportedAsErrors(): void
+    {
+        $response = new JsonResponse(['name' => 'treblle']);
+        // \Illuminate\Validation\ValidationException::class is a default entry in 'ignore_exceptions' config
+        $response->withException(ValidationException::withMessages(['key' => 'Error message']));
+
+        $this->treblleMiddleware->prepareResponseData($response);
+
+        $payload = $this->treblleMiddleware->getPayload();
+        $this->assertEmpty($payload['data']['errors']);
+        $this->assertArrayHasKey('response', $payload['data']);
     }
 }


### PR DESCRIPTION
This fixes issue https://github.com/Treblle/treblle-laravel/issues/37 

By adding a list of exception classes in the `ignore_exceptions`  array in the treblle.php file, our ignored exceptions do not get sent to the treblle console as errors.

I added two tests to verify the changes work and hasn't broken anything.

Hoping this is good enough to be accepted.