### PR TITLE
[CRITICAL] Set request API Key Using Package Config Variables

### DIFF
--- a/src/TreblleServiceProvider.php
+++ b/src/TreblleServiceProvider.php
@@ -72,7 +72,7 @@ final class TreblleServiceProvider extends ServiceProvider
                 request: Http::baseUrl(
                     url: 'https://app-api.treblle.com/v1/',
                 )->withToken(
-                    token: 'Y8fNzfhRab9FMeHXXbxT6Q0qqfmmTBKq',
+                    token: config('treblle.api_key'),
                 )->timeout(
                     seconds: 15,
                 )->withHeaders([


### PR DESCRIPTION
- This PR fixed the issue of request not hitting the dashboard because Treblle API was hardcoded inside the package. I believe this is an error of omission. 

How fast can we merge this PR @JustSteveKing 