### PR TITLE
Don't make `TreblleMiddleware` final

### DIFF
--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -17,7 +17,7 @@ use Treblle\Exceptions\TreblleApiException;
 use Treblle\Factories\DataFactory;
 use Treblle\Treblle;
 
-final class TreblleMiddleware
+class TreblleMiddleware
 {
     /**
      * @param DataFactory $factory


### PR DESCRIPTION
This allows us to extend the middleware. In my case, I need to reduce the amount of data being sent to Treblle.

My plan is to use the `Lottery` class to give some odds as to whether the data is sent or not.