### PR TITLE
Enable the project id to be passed when used in a route group

### DIFF
--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -32,8 +32,10 @@ class TreblleMiddleware
      * @return Response|JsonResponse
      * @throws ConfigurationException|InvalidArgumentException|TreblleApiException
      */
-    public function handle(Request $request, Closure $next): Response|JsonResponse
+    public function handle(Request $request, Closure $next, string $projectId = null): Response|JsonResponse
     {
+        $request->attributes->add(['projectId' => $projectId]);
+
         return $next($request);
     }
 
@@ -51,7 +53,8 @@ class TreblleMiddleware
                 request: $request,
                 response: $response,
                 loadTime: $this->getLoadTime(request: $request),
-            )
+            ),
+            projectId: $request->attributes->get('project_id')
         );
     }
 

--- a/src/Treblle.php
+++ b/src/Treblle.php
@@ -24,7 +24,7 @@ final class Treblle
      * @return void
      * @throws ConfigurationException|TreblleApiException
      */
-    public static function log(Endpoint $endpoint, Data $data): void
+    public static function log(Endpoint $endpoint, Data $data, string $projectId = null): void
     {
         if (empty($apiKey = config('treblle.api_key'))) {
             throw ConfigurationException::noApiKey();
@@ -32,7 +32,7 @@ final class Treblle
 
         $data = array_merge([
             'api_key' => $apiKey,
-            'project_id' => config('treblle.project_id'),
+            'project_id' => $projectId ?? config('treblle.project_id'),
             'version' => Treblle::VERSION,
             'sdk' => 'laravel',
         ], ['data' => $data->__toArray()]);


### PR DESCRIPTION
This enables the project id to be passed when used in route groups - see https://github.com/Treblle/treblle-laravel/issues/61