### PR TITLE
Update TreblleMiddleware.php

### DIFF
--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -63,7 +63,7 @@ class TreblleMiddleware
      */
     private function getLoadTime(Request $request): float
     {
-        if (isset($_SERVER['LARAVEL_OCTANE'])) {
+        if (isset($_SERVER['OCTANE_DATABASE_SESSION_TTL'])) {
             if (config('octane.server') === 'swoole') {
                 return (float) microtime(true) - floatval(Cache::store('octane')->get(app('treblle-identifier')));
             }


### PR DESCRIPTION
For some reason the only way to safely recognize that a given server is using Octane is by using the ENV variable of `OCTANE_DATABASE_SESSION_TTL`. Everything else just doesn't work reliably.