### PR TITLE
Fix call to pushMiddleware

### DIFF
--- a/src/TreblleServiceProvider.php
+++ b/src/TreblleServiceProvider.php
@@ -55,7 +55,7 @@ final class TreblleServiceProvider extends ServiceProvider implements Deferrable
             });
         }
 
-        $this->app[Kernel::class]->pushMiddleware('treblle', TreblleMiddleware::class);
+        $this->app[Kernel::class]->pushMiddleware(TreblleMiddleware::class);
     }
 
     /**


### PR DESCRIPTION
pushMiddleware only accepts one argument

Without this change I get error:
```
Illuminate\Contracts\Container\BindingResolutionException: Target class [treblle] does not exist.
```