### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
             "./vendor/bin/phpunit"
         ]
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
         "preferred-install": "dist",


### PR DESCRIPTION
I have a suspicion this is what's causing the 3.* to be the default install.