### PR TITLE
Add "testing" to list of ignored environments by default

### DIFF
--- a/config/treblle.php
+++ b/config/treblle.php
@@ -14,7 +14,7 @@ return [
     /*
      * Define which environments should Treblle ignore and not monitor
      */
-    'ignored_environments' => env('TREBLLE_IGNORED_ENV', 'dev,test'),
+    'ignored_environments' => env('TREBLLE_IGNORED_ENV', 'dev,test,testing'),
 
     /*
      * Define which fields should be masked before leaving the server


### PR DESCRIPTION
PHPUnit, by default, uses the "testing" environment.  Can we add that to the list of automatically ignored environments by default?