### PR TITLE
feat: Treblle Middleware works with zero latency now

### DIFF
--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -51,21 +51,38 @@ class TreblleMiddleware
      */
     public function terminate(Request $request, JsonResponse|Response $response): void
     {
+        if (!function_exists('pcntl_fork')) {
+            $this->collectData($request, $response);
+            return;
+        }
+
         $pid = pcntl_fork();
 
-        if ($this->isChildProcess($pid)) {
-            Treblle::log(
-                endpoint: Endpoint::PUNISHER,
-                data: $this->factory->make(
-                    request: $request,
-                    response: $response,
-                    loadTime: \microtime(true) - self::$start,
-                ),
-                projectId: self::$project ?? (string) \config('treblle.project_id'),
-            );
-
-            $this->killProcessWithId(getmypid());
+        if ($this->isUnableToForkProcess($pid)) {
+            $this->collectData($request, $response);
+            return;
         }
+
+        if ($this->isChildProcess($pid)) {
+            $this->collectData($request, $response);
+            $this->killProcessWithId((int)getmypid());
+        }
+    }
+
+    /**
+     * @throws ConfigurationException |TreblleApiException
+     */
+    protected function collectData(Request $request, JsonResponse|Response $response): void
+    {
+        Treblle::log(
+            endpoint: Endpoint::PUNISHER,
+            data: $this->factory->make(
+                request: $request,
+                response: $response,
+                loadTime: \microtime(true) - self::$start,
+            ),
+            projectId: self::$project ?? (string) \config('treblle.project_id'),
+        );
     }
 
     private function isChildProcess(int $pid): bool
@@ -73,8 +90,13 @@ class TreblleMiddleware
         return $pid === 0;
     }
 
-    private function killProcessWithId(int $pid): string|false
+    private function isUnableToForkProcess(int $pid): bool
     {
-        return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN'  ? exec("taskkill /F /T /PID $pid") : exec("kill -9 $pid");
+        return $pid === -1;
+    }
+
+    private function killProcessWithId(int $pid): void
+    {
+        strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? exec("taskkill /F /T /PID $pid") : exec("kill -9 $pid");
     }
 }


### PR DESCRIPTION
## Problem:
We wanted to have as much as low latency we could for Treblle data collection APIs on the SDK level.

## Solution:
This PR uses [pcntl_fork](https://www.php.net/manual/en/function.pcntl-fork.php) extension, which is already part of almost all the PHP installations.

Had look at the alternatives like [AMPHP](https://amphp.org/), [Spatie Fork](https://github.com/spatie/fork) and even looked into Laravel Octane code. alternatives where nice but they had there own requirements. 

Spatie Fork package looked nice though, but we wont be using full package functionalities so didnt make sense to add one more dependency, when we can walk away with simple solution. 

## Details:

creates a fork of current process, meaning duplicates current process in layman term.

```php
$pid = pcntl_fork();
```

all the below code runs in both the processes after fork, so we check if process is child or not with $pid == 0;
child process has $pid always 0

major problem with `pcntl_fork` function is, parent process might need data from child process 
and because of which it doesnt kills the process properly and hence [zombie processes](https://en.wikipedia.org/wiki/Zombie_process) are created. So we have to kill it manually so it doesnt becomes resource heavy.

```php
private function killProcessWithId($pid): string|false
{
   return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN'  ? exec("taskkill /F /T /PID $pid") : exec("kill -9 $pid");
}
```