### PR TITLE
bump of version for phputils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "treblle/utils": "^0.1.1"
+        "treblle/utils": "^0.2.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.7.0",


### PR DESCRIPTION
bumps the version of phputils to fix the underlying issue of masking authentication where there is less than 2 entries in the array