### PR TITLE
Adding Trace ID header to request and response in middleware

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,3 @@ jobs:
 
       - name: Execute the tests
         run: vendor/bin/phpunit --testdox
-
-      - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@main
-        env:
-            QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -44,15 +44,17 @@ class TreblleMiddleware
         self::$start = microtime(true);
         self::$project = $projectId;
 
-        $request->headers->add([
-            'X-TREBLLE-TRACE-ID' => $id = Str::uuid(),
-        ]);
+        if (! $request->headers->has('X-TREBLLE-TRACE-ID')) {
+            $request->headers->add([
+                'X-TREBLLE-TRACE-ID' => $id = Str::uuid(),
+            ]);
+        }
 
         /** @var SymfonyResponse $response */
         $response = $next($request);
 
         $response->headers->add([
-            'X-TREBLLE-TRACE-ID' => $id,
+            'X-TREBLLE-TRACE-ID' => $request->headers->get('X-TREBLLE-TRACE-ID'),
         ]);
 
         return $response;

--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -8,6 +8,7 @@ use Closure;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Treblle\Exceptions\ConfigurationException;
 use Treblle\Exceptions\TreblleApiException;
@@ -43,7 +44,18 @@ class TreblleMiddleware
         self::$start = microtime(true);
         self::$project = $projectId;
 
-        return $next($request);
+        $request->headers->add([
+            'X-TREBLLE-TRACE-ID' => $id = Str::uuid(),
+        ]);
+
+        /** @var SymfonyResponse $response */
+        $response = $next($request);
+
+        $response->headers->add([
+            'X-TREBLLE-TRACE-ID' => $id,
+        ]);
+
+        return $response;
     }
 
     /**

--- a/tests/Middleware/TreblleMiddlewareTest.php
+++ b/tests/Middleware/TreblleMiddlewareTest.php
@@ -11,6 +11,13 @@ use Treblle\Tests\TestCase;
 
 final class TreblleMiddlewareTest extends TestCase
 {
+    protected function newMiddleware(): TreblleMiddleware
+    {
+        return app()->make(
+            abstract: TreblleMiddleware::class,
+        );
+    }
+
     /**
      * @test
      * @return void
@@ -20,12 +27,7 @@ final class TreblleMiddlewareTest extends TestCase
         $request = new Request();
         $response = new Response();
 
-        /**
-         * @var TreblleMiddleware $middleware
-         */
-        $middleware = app()->make(
-            abstract: TreblleMiddleware::class,
-        );
+        $middleware = $this->newMiddleware();
 
         $middlewareResponse = $middleware->handle(
             request: $request,
@@ -35,6 +37,25 @@ final class TreblleMiddlewareTest extends TestCase
         $this->assertInstanceOf(
             expected: Response::class,
             actual: $middlewareResponse,
+        );
+    }
+
+    /** @test */
+    public function it_adds_trace_id_to_response(): void
+    {
+        $request = new Request();
+        $response = new Response();
+
+        $middleware = $this->newMiddleware();
+
+        $middlewareResponse = $middleware->handle(
+            request: $request,
+            next: fn () => $response,
+        );
+
+        $this->assertArrayHasKey(
+            key: 'x-treblle-trace-id',
+            array: $middlewareResponse->headers->all(),
         );
     }
 }


### PR DESCRIPTION
This PR adds the `X-TREBLLE-TRACE-ID` to the request and response going through your Laravel API, so that we can stitch calls to other APIs you have and see the communication between them.