### PR TITLE
Feature/add trace

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1 ]
+        php: [ 8.1, 8.2 ]
         laravel: [ 9.*, 10.* ]
         exclude:
           - php: 8.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1, 8.2 ]
+        php: [ 8.1, 8.2, 8.3 ]
         laravel: [ 9.*, 10.* ]
         exclude:
           - php: 8.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,3 @@ jobs:
 
       - name: Execute the tests
         run: vendor/bin/phpunit --testdox
-
-      - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@main
-        env:
-            QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/tests/Middleware/TreblleMiddlewareTest.php
+++ b/tests/Middleware/TreblleMiddlewareTest.php
@@ -11,21 +11,20 @@ use Treblle\Tests\TestCase;
 
 final class TreblleMiddlewareTest extends TestCase
 {
-    /**
-     * @test
-     * @return void
-     */
+    protected function newMiddleware(): TreblleMiddleware
+    {
+        return app()->make(
+            abstract: TreblleMiddleware::class,
+        );
+    }
+
+    /** @test */
     public function it_returns_a_response(): void
     {
         $request = new Request();
         $response = new Response();
 
-        /**
-         * @var TreblleMiddleware $middleware
-         */
-        $middleware = app()->make(
-            abstract: TreblleMiddleware::class,
-        );
+        $middleware = $this->newMiddleware();
 
         $middlewareResponse = $middleware->handle(
             request: $request,
@@ -35,6 +34,25 @@ final class TreblleMiddlewareTest extends TestCase
         $this->assertInstanceOf(
             expected: Response::class,
             actual: $middlewareResponse,
+        );
+    }
+
+    /** @test */
+    public function it_adds_trace_id_to_response(): void
+    {
+        $request = new Request();
+        $response = new Response();
+
+        $middleware = $this->newMiddleware();
+
+        $middlewareResponse = $middleware->handle(
+            request: $request,
+            next: fn () => $response,
+        );
+
+        $this->assertArrayHasKey(
+            key: 'x-treblle-trace-id',
+            array: $middlewareResponse->headers->all(),
         );
     }
 }


### PR DESCRIPTION
This PR adds a new `X-TREBLLE-TRACE-ID` to requests coming through your API so that we can start to map the bigger picture of what your API touches, and what touches your API.