### PR TITLE
removed conflicting check

### DIFF
--- a/src/Treblle.php
+++ b/src/Treblle.php
@@ -29,9 +29,6 @@ final class Treblle
             return;
         }
 
-        if (! in_array(\config('app.env'), \explode(',', $treblleConfig['ignored_environments']), true)) {
-            return;
-        }
 
         /** @var string $appEnvironment */
         $appEnvironment = config('app.env', 'unknownEnvironment');


### PR DESCRIPTION
I'm playing with Treblle and trying to integrate this library.

It seems some work was recently done on the environment check and the current version has 2 pair of checks that contradict themself:

```
        if (! in_array(\config('app.env'), \explode(',', $treblleConfig['ignored_environments']), true)) {
            return;
        }
```
this will basically reject all environments, except the ones in the ignored_enviroments

the rest of the check will reject all environments in ignored_environments

fixes #88 
