### PR TITLE
feature: adding server hostname to server object

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "treblle/utils": "^0.3.3"
+        "treblle/utils": "^0.4.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.7.0",

--- a/src/Factories/DataFactory.php
+++ b/src/Factories/DataFactory.php
@@ -71,6 +71,7 @@ final class DataFactory
                     php_uname('m'),
                 ),
                 (string) $request->server('HTTP_ACCEPT_ENCODING'),
+                $request->host(),
             ),
             new Language(
                 'php',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -84,6 +84,7 @@ class TestCase extends BaseTestCase
                     architecture: 'arm',
                 ),
                 encoding: 'gzip',
+                hostname: 'localhost',
             ),
             language: new Language(
                 name: 'PHP',


### PR DESCRIPTION
This PR updates the `treblle/utils` package, and adds the hostname detection in the data factory. This allows you as a user to recognise which host each request is coming from.