### PR TITLE
fix: moving logic to terminate method

### DIFF
--- a/src/Http/Endpoint.php
+++ b/src/Http/Endpoint.php
@@ -9,4 +9,10 @@ enum Endpoint: string
     case ROCK_N_ROLLA = 'https://rocknrolla.treblle.com';
     case PUNISHER = 'https://punisher.treblle.com';
     case SICARIO = 'https://sicario.treblle.com';
+
+    public static function random(): self
+    {
+        $cases = self::cases();
+        return $cases[array_rand($cases)];
+    }
 }

--- a/tests/Middleware/TreblleMiddlewareTest.php
+++ b/tests/Middleware/TreblleMiddlewareTest.php
@@ -48,25 +48,6 @@ final class TreblleMiddlewareTest extends TestCase
     }
 
     #[Test]
-    public function it_adds_trace_id_to_response(): void
-    {
-        $request = new Request();
-        $response = new Response();
-
-        $middleware = $this->newMiddleware();
-
-        $middlewareResponse = $middleware->handle(
-            request: $request,
-            next: fn () => $response,
-        );
-
-        $this->assertArrayHasKey(
-            key: 'x-treblle-trace-id',
-            array: $middlewareResponse->headers->all(),
-        );
-    }
-
-    #[Test]
     public function it_will_not_log_if_config_is_not_ready(): void
     {
         Treblle::log(


### PR DESCRIPTION
This PR moves the main logic to the terminate method, for the rare cases that the 'handle' method isn't called but terminate is.

I have also moved the random `Endpoint` selection to a static method on the Enum itself.

This means I have had to remove a test for checking if the header is set for `X-TREBLLE-TRACE-ID` as terminate is a void return. 