### PR TITLE
Fix load time not being difference between start and now

### DIFF
--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -71,11 +71,16 @@ class TreblleMiddleware
             data: $this->factory->make(
                 request: $request,
                 response: $response,
-                loadTime: $_SERVER['REQUEST_TIME_FLOAT']
-                    ?? (defined('LARAVEL_START') ? LARAVEL_START : null)
-                    ?? microtime(true),
+                loadTime: microtime(true) - $this->startTime(),
             ),
             projectId: self::$project ?? (string) config('treblle.project_id'),
         );
+    }
+
+    private function startTime(): float
+    {
+        return $_SERVER['REQUEST_TIME_FLOAT']
+            ?? (defined('LARAVEL_START') ? LARAVEL_START : null)
+            ?? microtime(true);
     }
 }


### PR DESCRIPTION
Here is a quickfix for the load time not being calculated as a difference anymore. 

Only problem with this solution is if both `LARAVEL_START` and `REQUEST_TIME_FLOAT` is not set, than we are essentially comparing `microtime(true) - microtime(true)` which would prob. be `0`. 

Not sure if it's an actual issue, but maybe better for that case to return `null` instead or something like that? 