### PR TITLE
fix(developer-experience): prevent an annoying exception from being raised when handling empty response

### DIFF
--- a/src/Factories/DataFactory.php
+++ b/src/Factories/DataFactory.php
@@ -34,17 +34,18 @@ final class DataFactory
 
         $errors = [];
 
-        try {
-            $responseBody = $this->masker->mask(
-                (array) json_decode(
-                    (string) $response->getContent(),
-                    true,
-                    512,
-                    JSON_THROW_ON_ERROR
-                ),
-            );
-        } catch (Throwable) {
-            $responseBody = '{}';
+        $responseContent = (string) $response->getContent();
+        $responseBody = '{}';
+
+        if (!empty($responseContent)) {
+            $decodedJson = json_decode($responseContent, true, 512);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                try {
+                    $responseBody = $this->masker->mask((array) $decodedJson);
+                } catch (Throwable) {
+                    // Handle masking error by falling back to '{}'
+                }
+            }
         }
 
         if (! empty($response->exception)) {


### PR DESCRIPTION
Xdebug has a feature to "Break on exception" - generally this is very useful to quickly find exceptions being raised in the application as most of them find their way to the response.

In the changed code, Treblle Laravel integration seems to be using exceptions for control flow - and raises an exception when the response is empty (very common with 204 Status code for example).

This breaks my debugging workflow because I see this exception being raised on every 204 that I return from the app.

To get around this, I rewrote the logic not to raise the exception, but check the error conditions explicitly.