### PR TITLE
Monitoring for third party APIs

### DIFF
--- a/config/treblle.php
+++ b/config/treblle.php
@@ -85,4 +85,25 @@ return [
          */
         'queue' => env('TREBLLE_QUEUE_NAME', 'default'),
     ],
+
+    /** MONITORING  */
+    'monitoring' => [
+        'api1234' => [
+            'host' => 'https://example.com',
+            'endpoints' => [
+                'endpoint123' => [
+                    'path' => '/news',
+                    'method' => 'POST',
+                ],
+                'endpoint321' => [
+                    'path' => '/news',
+                    'method' => 'GET',
+                ],
+                'endpoint213' => [
+                    'path' => '/news/{id}/articles',
+                    'method' => 'GET',
+                ],
+            ],
+        ],
+    ],
 ];

--- a/src/Config/Validator.php
+++ b/src/Config/Validator.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\Config;
+
+use Treblle\Laravel\Exceptions\TreblleException;
+
+/**
+ * Validation class, for required configuration properties
+ *
+ * Tasks:
+ *  - check if sdk key is set
+ *  - check if api key
+ *  - check for excluded environments
+ *
+ * @package Treblle\Laravel\Config
+ */
+final class Validator
+{
+    private bool $debugEnabled;
+
+    private array $ignoredEnvironments;
+
+    public function __construct()
+    {
+        $this->debugEnabled = config('treblle.debug');
+
+        $ignoredEnvs = array_map('trim', explode(',', config('treblle.ignored_environments', '') ?? ''));
+        $this->ignoredEnvironments = array_flip($ignoredEnvs);
+    }
+
+    /**
+     * Validates if sdk key and api key are set
+     *
+     * @throws TreblleException
+     */
+    public function validateKeys(): void
+    {
+        // Validate configuration - fail silently if missing to never break the API
+        if (! config('treblle.sdk_token')) {
+            $this->logConfigError('TREBLLE_SDK_TOKEN is not configured. Treblle monitoring disabled.');
+
+            throw new TreblleException('Treblle sdk key not found');
+        }
+
+        if (! config('treblle.api_key')) {
+            $this->logConfigError('TREBLLE_API_KEY is not configured. Treblle monitoring disabled.');
+
+            throw new TreblleException('Treblle api key not found');
+        }
+    }
+
+    /**
+     * Validates that current environments is not ignored
+     *
+     * @throws TreblleException
+     */
+    public function validateEnvironment(): void
+    {
+        if (isset($this->ignoredEnvironments[app()->environment()])) {
+            throw new TreblleException('Current environment is ignored');
+        }
+    }
+
+    /**
+     * Log configuration errors when debug mode is enabled.
+     *
+     * @param  string  $message  The error message
+     */
+    private function logConfigError(string $message): void
+    {
+        if ($this->debugEnabled) {
+            logger()->warning('[Treblle] ' . $message);
+        }
+    }
+}

--- a/src/DataTransferObject/BasePayloadData.php
+++ b/src/DataTransferObject/BasePayloadData.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\DataTransferObject;
+
+use Treblle\Php\DataTransferObject\Data;
+use Treblle\Laravel\Monitor\DataTransferObjects\MonitoringData;
+
+/**
+ * Base parameters required for any PayloadData DataTransferObject.
+ * Child classes can extend and add additional properties required for specific type of payload data
+ * Each child is required to define payload data type and implement getData method
+ *
+ * @package Treblle\Laravel\DataTransferObject
+ */
+abstract class BasePayloadData
+{
+    /**
+     * The SDK name
+     */
+    protected string $sdkName;
+
+    /**
+     * The SDK version
+     */
+    protected float $sdkVersion;
+
+    /**
+     * Optional custom Treblle endpoint URL
+     */
+    protected ?string $url = null;
+
+    /**
+     * Whether debug mode is enabled
+     */
+    protected bool $debug = false;
+
+    /**
+     * The Treblle API key
+     */
+    protected string $apiKey;
+
+    /**
+     * The Treblle SDK token
+     */
+    protected string $sdkToken;
+
+    /**
+     * Type od payload, needs to be overridden in child classes
+     */
+    protected string $type = '';
+
+    abstract public function setData(Data|MonitoringData $data);
+
+    public function setApiKey(string $apiKey): self
+    {
+        $this->apiKey = $apiKey;
+
+        return $this;
+    }
+
+    public function setSdkToken(string $sdkToken): self
+    {
+        $this->sdkToken = $sdkToken;
+
+        return $this;
+    }
+
+    public function setSdkName(string $sdkName): self
+    {
+        $this->sdkName = $sdkName;
+
+        return $this;
+    }
+
+    public function setSdkVersion(float $sdkVersion): self
+    {
+        $this->sdkVersion = $sdkVersion;
+
+        return $this;
+    }
+
+    public function withUrl(?string $url = null): self
+    {
+        $this->url = $url ?? config('treblle.url');
+
+        return $this;
+    }
+
+    public function withDebug(): self
+    {
+        $this->debug = config('treblle.debug');
+
+        return $this;
+    }
+
+    public function isDebug(): bool
+    {
+        return $this->debug;
+    }
+
+    public function getApiKey(): string
+    {
+        return $this->apiKey;
+    }
+
+    public function getSdkToken(): string
+    {
+        return $this->sdkToken;
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'api_key' => $this->apiKey,
+            'sdk_token' => $this->sdkToken,
+            'sdk' => $this->sdkName,
+            'version' => $this->sdkVersion,
+        ];
+    }
+}

--- a/src/DataTransferObject/BasePayloadData.php
+++ b/src/DataTransferObject/BasePayloadData.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Treblle\Laravel\DataTransferObject;
 
-use Treblle\Php\DataTransferObject\Data;
-use Treblle\Laravel\Monitor\DataTransferObjects\MonitoringData;
+use JsonSerializable;
 
 /**
  * Base parameters required for any PayloadData DataTransferObject.
@@ -51,7 +50,7 @@ abstract class BasePayloadData
      */
     protected string $type = '';
 
-    abstract public function setData(Data|MonitoringData $data);
+    abstract public function setData(JsonSerializable $data);
 
     public function setApiKey(string $apiKey): self
     {

--- a/src/DataTransferObject/TrebllePayloadData.php
+++ b/src/DataTransferObject/TrebllePayloadData.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Treblle\Laravel\DataTransferObject;
 
-use Treblle\Laravel\Monitor\DataTransferObjects\MonitoringData;
+use JsonSerializable;
 use Treblle\Laravel\Monitor\Enums\PayloadDataType;
-use Treblle\Php\DataTransferObject\Data;
 
 /**
  * Data Transfer Object for Treblle payload.
@@ -26,9 +25,9 @@ final class TrebllePayloadData extends BasePayloadData
     /**
      * The core Treblle data object containing request/response/errors
      */
-    private Data $data;
+    private JsonSerializable $data;
 
-    public function setData(Data|MonitoringData $data): self
+    public function setData(JsonSerializable $data): self
     {
         $this->data = $data;
 

--- a/src/DataTransferObject/TrebllePayloadData.php
+++ b/src/DataTransferObject/TrebllePayloadData.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Treblle\Laravel\DataTransferObject;
 
+use Treblle\Laravel\Monitor\DataTransferObjects\MonitoringData;
+use Treblle\Laravel\Monitor\Enums\PayloadDataType;
 use Treblle\Php\DataTransferObject\Data;
 
 /**
@@ -13,31 +15,24 @@ use Treblle\Php\DataTransferObject\Data;
  * serialized and passed to queue jobs. By extracting data from Request/Response
  * objects before queuing, we avoid serialization issues with Closures and
  * other non-serializable properties.
- *
- * @package Treblle\Laravel\DataTransferObject
  */
-final readonly class TrebllePayloadData
+final class TrebllePayloadData extends BasePayloadData
 {
     /**
-     * Create a new TrebllePayloadData instance.
-     *
-     * @param string $apiKey The Treblle API key
-     * @param string $sdkToken The Treblle SDK token
-     * @param string $sdkName The SDK name
-     * @param float $sdkVersion The SDK version
-     * @param Data $data The core Treblle data object containing request/response/errors
-     * @param string|null $url Optional custom Treblle endpoint URL
-     * @param bool $debug Whether debug mode is enabled
+     * Indicates that this is original api
      */
-    public function __construct(
-        public string $apiKey,
-        public string $sdkToken,
-        public string $sdkName,
-        public float $sdkVersion,
-        public Data $data,
-        public string|null $url = null,
-        public bool $debug = false
-    ) {
+    protected string $type = PayloadDataType::ORIGIN->value;
+
+    /**
+     * The core Treblle data object containing request/response/errors
+     */
+    private Data $data;
+
+    public function setData(Data|MonitoringData $data): self
+    {
+        $this->data = $data;
+
+        return $this;
     }
 
     /**
@@ -48,11 +43,8 @@ final readonly class TrebllePayloadData
     public function toArray(): array
     {
         return [
-            'api_key' => $this->apiKey,
-            'sdk_token' => $this->sdkToken,
-            'sdk' => $this->sdkName,
-            'version' => $this->sdkVersion,
-            'data' => $this->data,
+            ...parent::toArray(),
+            ...get_object_vars($this),
         ];
     }
 }

--- a/src/Factories/PayloadDataFactory.php
+++ b/src/Factories/PayloadDataFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\Factories;
+
+use Treblle\Laravel\TreblleServiceProvider;
+use Treblle\Laravel\Exceptions\TreblleException;
+use Treblle\Laravel\DataTransferObject\BasePayloadData;
+use Treblle\Laravel\DataTransferObject\TrebllePayloadData;
+use Treblle\Laravel\Monitor\DataTransferObjects\MonitoringPayloadData;
+
+/**
+ * Constructs object of type PayloadData
+ *
+ * @package Treblle\Laravel\Factories
+ */
+final class PayloadDataFactory
+{
+    public const TREBLLE = 'treblle';
+    public const MONITORING = 'monitoring';
+
+    /**
+     * Creates a new object of type PayloadData
+     *
+     * @throws TreblleException
+     */
+    public static function create(string $type): BasePayloadData
+    {
+        $object = match ($type) {
+            self::MONITORING => new MonitoringPayloadData(),
+            self::TREBLLE => new TrebllePayloadData(),
+            default => throw new TreblleException('Unknown payload type'),
+        };
+
+        $object->setApiKey((string) config('treblle.api_key'))
+            ->setSdkToken((string) config('treblle.sdk_token'))
+            ->setSdkName(TreblleServiceProvider::SDK_NAME)
+            ->setSdkVersion(TreblleServiceProvider::SDK_VERSION)
+            ->withUrl()
+            ->withDebug();
+
+        return $object;
+    }
+}

--- a/src/Jobs/SendTreblleData.php
+++ b/src/Jobs/SendTreblleData.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace Treblle\Laravel\Jobs;
 
-use Throwable;
 use Illuminate\Bus\Queueable;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+use Treblle\Laravel\DataTransferObject\BasePayloadData;
 use Treblle\Laravel\DataTransferObject\TrebllePayloadData;
+use Treblle\Laravel\Monitor\Enums\PayloadDataType;
 
 /**
  * Queue job for sending Treblle monitoring data asynchronously.
- *
- * @package Treblle\Laravel\Jobs
  */
 final class SendTreblleData implements ShouldQueue
 {
@@ -28,38 +28,30 @@ final class SendTreblleData implements ShouldQueue
 
     /**
      * The number of times the job may be attempted.
-     *
-     * @var int
      */
     public int $tries = 3;
 
     /**
      * The number of seconds to wait before retrying the job.
-     *
-     * @var int
      */
     public int $backoff = 5;
 
     /**
      * The number of seconds the job can run before timing out.
-     *
-     * @var int
      */
     public int $timeout = 10;
 
     /**
      * Create a new job instance.
      *
-     * @param TrebllePayloadData $payloadData The pre-extracted Treblle payload data
+     * @param  TrebllePayloadData  $payloadData  The pre-extracted Treblle payload data
      */
     public function __construct(
-        private readonly TrebllePayloadData $payloadData
-    ) {
-    }
+        private readonly BasePayloadData $payloadData
+    ) {}
 
     /**
      * Execute the job.
-     * @return void
      */
     public function handle(): void
     {
@@ -71,11 +63,11 @@ final class SendTreblleData implements ShouldQueue
             $url = $this->getBaseUrl();
 
             // Log the payload being sent (only in debug mode)
-            if ($this->payloadData->debug) {
+            if ($this->payloadData->isDebug()) {
                 Log::info('Treblle: Sending payload', [
                     'url' => $url,
-                    'api_key' => $this->payloadData->apiKey,
-                    'sdk_token' => mb_substr($this->payloadData->sdkToken, 0, 10) . '...',
+                    'api_key' => $this->payloadData->getApiKey(),
+                    'sdk_token' => mb_substr($this->payloadData->getSdkToken(), 0, 10) . '...',
                     'payload_size' => mb_strlen($jsonPayload),
                     'compressed_size' => mb_strlen($compressedPayload),
                     'payload' => json_decode($jsonPayload, true), // Log as array for better readability
@@ -89,14 +81,14 @@ final class SendTreblleData implements ShouldQueue
                 ->withHeaders([
                     'Content-Type' => 'application/json',
                     'Content-Encoding' => 'gzip',
-                    'x-api-key' => $this->payloadData->sdkToken,
+                    'x-api-key' => $this->payloadData->getSdkToken(),
                     'Accept-Encoding' => 'gzip',
                 ])
                 ->withBody($compressedPayload, 'application/json')
                 ->post($url);
 
             // Log the response (only in debug mode)
-            if ($this->payloadData->debug) {
+            if ($this->payloadData->isDebug()) {
                 Log::info('Treblle: Response received', [
                     'status_code' => $response->status(),
                     'headers' => $response->headers(),
@@ -107,10 +99,10 @@ final class SendTreblleData implements ShouldQueue
             // Always log errors (important for troubleshooting)
             Log::error('Treblle: Failed to send data', [
                 'error' => $throwable->getMessage(),
-                'trace' => $this->payloadData->debug ? $throwable->getTraceAsString() : null,
+                'trace' => $this->payloadData->isDebug() ? $throwable->getTraceAsString() : null,
             ]);
 
-            if ($this->payloadData->debug) {
+            if ($this->payloadData->isDebug()) {
                 throw $throwable;
             }
 
@@ -121,6 +113,7 @@ final class SendTreblleData implements ShouldQueue
 
     /**
      * Get the base URL for Treblle API.
+     * Based on payload data type, it will fetch url for original or monitoring API
      *
      * If a custom URL is provided, it will be used. Otherwise, a random
      * endpoint from the available Treblle servers is selected for load
@@ -136,6 +129,12 @@ final class SendTreblleData implements ShouldQueue
             'https://sicario.treblle.com',
         ];
 
-        return $this->payloadData->url ?? $urls[array_rand($urls)];
+        if ($this->payloadData->getType() === PayloadDataType::THIRD_PARTY->value) {
+            $urls = [
+                'https://example.com',
+            ];
+        }
+
+        return $this->payloadData->getUrl() ?? $urls[array_rand($urls)];
     }
 }

--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use Treblle\Laravel\Config\Validator;
+use Treblle\Laravel\DataTransferObject\Data\TreblleDataAdapter;
 use Treblle\Php\Factory\TreblleFactory;
 use Treblle\Php\DataTransferObject\Data;
 use Treblle\Laravel\Jobs\SendTreblleData;

--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -9,15 +9,17 @@ use Throwable;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
+use Treblle\Laravel\Config\Validator;
 use Treblle\Php\Factory\TreblleFactory;
 use Treblle\Php\DataTransferObject\Data;
 use Treblle\Laravel\Jobs\SendTreblleData;
 use Treblle\Php\DataTransferObject\Error;
 use Treblle\Laravel\TreblleServiceProvider;
 use Treblle\Php\Helpers\SensitiveDataMasker;
+use Treblle\Laravel\Exceptions\TreblleException;
+use Treblle\Laravel\Factories\PayloadDataFactory;
 use Treblle\Php\DataProviders\PhpLanguageDataProvider;
 use Treblle\Php\DataProviders\InMemoryErrorDataProvider;
-use Treblle\Laravel\DataTransferObject\TrebllePayloadData;
 use Treblle\Laravel\DataProviders\LaravelRequestDataProvider;
 use Treblle\Php\DataProviders\SuperGlobalsServerDataProvider;
 use Treblle\Laravel\DataProviders\LaravelResponseDataProvider;
@@ -37,8 +39,6 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
  * - Sensitive data masking
  * - Exception tracking
  * - Non-blocking data transmission
- *
- * @package Treblle\Laravel\Middlewares
  */
 final class TreblleMiddleware
 {
@@ -46,8 +46,6 @@ final class TreblleMiddleware
      * Cached configuration values for performance optimization.
      */
     private bool $enabled;
-
-    private array $ignoredEnvironments;
 
     private bool $queueEnabled;
 
@@ -62,14 +60,10 @@ final class TreblleMiddleware
     /**
      * Initialize middleware with cached configuration.
      */
-    public function __construct()
-    {
+    public function __construct(
+        private Validator $configValidator,
+    ) {
         $this->enabled = (bool) config('treblle.enable', true);
-
-        // Parse ignored environments once and create hash map for O(1) lookups
-        $ignoredEnvs = array_map('trim', explode(',', config('treblle.ignored_environments', '') ?? ''));
-        $this->ignoredEnvironments = array_flip($ignoredEnvs);
-
         $this->queueEnabled = (bool) config('treblle.queue.enabled', false);
         $this->queueConnection = config('treblle.queue.connection');
         $this->queueName = config('treblle.queue.queue', 'default');
@@ -92,20 +86,21 @@ final class TreblleMiddleware
      * results in silent failure (with debug logging) to ensure Treblle never
      * breaks your API.
      *
-     * @param Request $request The incoming HTTP request
-     * @param Closure $next The next middleware in the pipeline
-     * @param string|null $apiKey Optional API key override for this specific route
-     *
+     * @param  Request  $request  The incoming HTTP request
+     * @param  Closure  $next  The next middleware in the pipeline
+     * @param  string|null  $apiKey  Optional API key override for this specific route
      * @return mixed The response from the next middleware
      */
-    public function handle(Request $request, Closure $next, string|null $apiKey = null)
+    public function handle(Request $request, Closure $next, ?string $apiKey = null)
     {
         if (! $this->enabled) {
             return $next($request);
         }
 
         // O(1) hash lookup instead of O(n) in_array
-        if (isset($this->ignoredEnvironments[app()->environment()])) {
+        try {
+            $this->configValidator->validateEnvironment();
+        } catch (TreblleException) {
             return $next($request);
         }
 
@@ -114,15 +109,9 @@ final class TreblleMiddleware
         }
 
         // Validate configuration - fail silently if missing to never break the API
-        if (! config('treblle.sdk_token')) {
-            $this->logConfigError('TREBLLE_SDK_TOKEN is not configured. Treblle monitoring disabled.');
-
-            return $next($request);
-        }
-
-        if (! config('treblle.api_key')) {
-            $this->logConfigError('TREBLLE_API_KEY is not configured. Treblle monitoring disabled.');
-
+        try {
+            $this->configValidator->validateKeys();
+        } catch (TreblleException) {
             return $next($request);
         }
 
@@ -133,20 +122,22 @@ final class TreblleMiddleware
     /**
      * Perform any final actions for the request lifecycle.
      *
-     * @param Request $request The HTTP request that was processed
-     * @param JsonResponse|Response|SymfonyResponse $response The response that was sent
-     *
-     * @return void
+     * @param  Request  $request  The HTTP request that was processed
+     * @param  JsonResponse|Response|SymfonyResponse  $response  The response that was sent
      */
     public function terminate(Request $request, JsonResponse|Response|SymfonyResponse $response): void
     {
         // O(1) hash lookup for ignored environments
-        if (isset($this->ignoredEnvironments[app()->environment()])) {
+        try {
+            $this->configValidator->validateEnvironment();
+        } catch (TreblleException) {
             return;
         }
 
         // Re-validate configuration (in case it was changed after handle())
-        if (! config('treblle.sdk_token') || ! config('treblle.api_key')) {
+        try {
+            $this->configValidator->validateKeys();
+        } catch (TreblleException) {
             return;
         }
 
@@ -166,10 +157,8 @@ final class TreblleMiddleware
      *
      * Wrapped in try-catch to ensure Treblle never breaks the application.
      *
-     * @param Request $request The HTTP request
-     * @param JsonResponse|Response|SymfonyResponse $response The HTTP response
-     *
-     * @return void
+     * @param  Request  $request  The HTTP request
+     * @param  JsonResponse|Response|SymfonyResponse  $response  The HTTP response
      */
     private function dispatchToQueue(Request $request, JsonResponse|Response|SymfonyResponse $response): void
     {
@@ -196,21 +185,22 @@ final class TreblleMiddleware
             }
 
             // Build serializable DTO with extracted data
-            $payloadData = new TrebllePayloadData(
-                apiKey: (string) config('treblle.api_key'),
-                sdkToken: (string) config('treblle.sdk_token'),
-                sdkName: TreblleServiceProvider::SDK_NAME,
-                sdkVersion: TreblleServiceProvider::SDK_VERSION,
-                data: new Data(
-                    $serverProvider->getServer(),
-                    $languageProvider->getLanguage(),
-                    $requestProvider->getRequest(),
-                    $responseProvider->getResponse(),
-                    $errorProvider->getErrors()
-                ),
-                url: config('treblle.url'),
-                debug: $this->debug
-            );
+            try {
+                $payloadData = PayloadDataFactory::create(PayloadDataFactory::TREBLLE);
+            } catch (TreblleException $e) {
+                if ($this->debug) {
+                    logger()->error('[Treblle] ' . $e->getMessage());
+                }
+                return;
+            }
+
+            $payloadData->setData(new Data(
+                $serverProvider->getServer(),
+                $languageProvider->getLanguage(),
+                $requestProvider->getRequest(),
+                $responseProvider->getResponse(),
+                $errorProvider->getErrors()
+            ));
 
             // Create and dispatch job with serializable data
             $job = new SendTreblleData($payloadData);
@@ -232,10 +222,8 @@ final class TreblleMiddleware
      *
      * Wrapped in try-catch to ensure Treblle never breaks the application.
      *
-     * @param Request $request The HTTP request
-     * @param JsonResponse|Response|SymfonyResponse $response The HTTP response
-     *
-     * @return void
+     * @param  Request  $request  The HTTP request
+     * @param  JsonResponse|Response|SymfonyResponse  $response  The HTTP response
      */
     private function sendSynchronously(Request $request, JsonResponse|Response|SymfonyResponse $response): void
     {
@@ -286,9 +274,7 @@ final class TreblleMiddleware
     /**
      * Log configuration errors when debug mode is enabled.
      *
-     * @param string $message The error message
-     *
-     * @return void
+     * @param  string  $message  The error message
      */
     private function logConfigError(string $message): void
     {
@@ -300,10 +286,8 @@ final class TreblleMiddleware
     /**
      * Log runtime errors when debug mode is enabled.
      *
-     * @param string $message The error message
-     * @param Throwable $exception The exception that was thrown
-     *
-     * @return void
+     * @param  string  $message  The error message
+     * @param  Throwable  $exception  The exception that was thrown
      */
     private function logError(string $message, Throwable $exception): void
     {

--- a/src/Monitor/DataTransferObjects/MonitoringData.php
+++ b/src/Monitor/DataTransferObjects/MonitoringData.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\Monitor\DataTransferObjects;
+
+/**
+ * Data Transfer Object for specific data needed for Treblle third party monitoring endpoints.
+ *
+ * @package Treblle\Laravel\Monitor\DataTransferObjects
+ */
+final readonly class MonitoringData
+{
+    public function __construct(
+        private int $statusCode,
+        private int $time, // Time of the API call
+        private int $duration, // Duration of API call
+        private string $apiId, // Unique id that identifies third party api
+        private string $endpointId, // Unique id that identifies endpoint in third party api
+        private array $config, // Whole user defined monitoring configuration will be passed
+    ) {}
+
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Monitor/DataTransferObjects/MonitoringData.php
+++ b/src/Monitor/DataTransferObjects/MonitoringData.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Treblle\Laravel\Monitor\DataTransferObjects;
 
+use JsonSerializable;
+
 /**
  * Data Transfer Object for specific data needed for Treblle third party monitoring endpoints.
  *
  * @package Treblle\Laravel\Monitor\DataTransferObjects
  */
-final readonly class MonitoringData
+final readonly class MonitoringData implements JsonSerializable
 {
     public function __construct(
         private int $statusCode,
@@ -20,7 +22,7 @@ final readonly class MonitoringData
         private array $config, // Whole user defined monitoring configuration will be passed
     ) {}
 
-    public function toArray(): array
+    public function jsonSerialize(): mixed
     {
         return get_object_vars($this);
     }

--- a/src/Monitor/DataTransferObjects/MonitoringPayloadData.php
+++ b/src/Monitor/DataTransferObjects/MonitoringPayloadData.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\Monitor\DataTransferObjects;
+
+use Treblle\Laravel\DataTransferObject\BasePayloadData;
+use Treblle\Laravel\Monitor\Enums\PayloadDataType;
+use Treblle\Php\DataTransferObject\Data;
+
+/**
+ * Data Transfer Object for Monitoring payload.
+ *
+ * This DTO holds the complete extracted payload data that can be safely
+ * serialized and passed to queue jobs.
+ *
+ * @package Treblle\Laravel\Monitor\DataTransferObjects
+ */
+final class MonitoringPayloadData extends BasePayloadData
+{
+    /**
+     * Indicates that this is third party api monitoring
+     */
+    protected string $type = PayloadDataType::THIRD_PARTY->value;
+
+    /**
+     * Data necessary for third party api's monitoring
+     */
+    private MonitoringData $data;
+
+    public function setData(Data|MonitoringData $data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            ...parent::toArray(),
+            ...get_object_vars($this),
+        ];
+    }
+}

--- a/src/Monitor/DataTransferObjects/MonitoringPayloadData.php
+++ b/src/Monitor/DataTransferObjects/MonitoringPayloadData.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace Treblle\Laravel\Monitor\DataTransferObjects;
 
-use Treblle\Laravel\DataTransferObject\BasePayloadData;
+use JsonSerializable;
 use Treblle\Laravel\Monitor\Enums\PayloadDataType;
-use Treblle\Php\DataTransferObject\Data;
+use Treblle\Laravel\DataTransferObject\BasePayloadData;
 
 /**
  * Data Transfer Object for Monitoring payload.
  *
  * This DTO holds the complete extracted payload data that can be safely
  * serialized and passed to queue jobs.
- *
- * @package Treblle\Laravel\Monitor\DataTransferObjects
  */
 final class MonitoringPayloadData extends BasePayloadData
 {
@@ -26,9 +24,9 @@ final class MonitoringPayloadData extends BasePayloadData
     /**
      * Data necessary for third party api's monitoring
      */
-    private MonitoringData $data;
+    private JsonSerializable $data;
 
-    public function setData(Data|MonitoringData $data): self
+    public function setData(JsonSerializable $data): self
     {
         $this->data = $data;
 

--- a/src/Monitor/Enums/PayloadDataType.php
+++ b/src/Monitor/Enums/PayloadDataType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Treblle\Laravel\Monitor\Enums;
+
+/**
+ *
+ * @package Treblle\Laravel\Monitor\Enums
+ */
+enum PayloadDataType: string
+{
+    case ORIGIN = 'origin';
+    case THIRD_PARTY = 'third_party';
+}

--- a/src/Monitor/Facades/TreblleMonitoring.php
+++ b/src/Monitor/Facades/TreblleMonitoring.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * Facade for Trebble third party aPI's monitoring
  *
- * @method static stopWatchStat()
+ * @method static stopWatchStart()
  * @method static stopWatchEnd()
  * @method static monitor(string|int $statusCode, string|int $apiId, string|int $endpointId)
  *

--- a/src/Monitor/Facades/TreblleMonitoring.php
+++ b/src/Monitor/Facades/TreblleMonitoring.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\Monitor\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * Facade for Trebble third party aPI's monitoring
+ *
+ * @method static monitor(string|int $statusCode, string|int $apiId, string|int $endpointId)
+ *
+ * @package Treblle\Laravel\Monitor\Facades
+ */
+final class TreblleMonitoring extends Facade
+{
+    public static function getFacadeAccessor(): string
+    {
+        return \Treblle\Laravel\Monitor\Services\TreblleMonitoring::class;
+    }
+}

--- a/src/Monitor/Facades/TreblleMonitoring.php
+++ b/src/Monitor/Facades/TreblleMonitoring.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\Facade;
 /**
  * Facade for Trebble third party aPI's monitoring
  *
+ * @method static stopWatchStat()
+ * @method static stopWatchEnd()
  * @method static monitor(string|int $statusCode, string|int $apiId, string|int $endpointId)
  *
  * @package Treblle\Laravel\Monitor\Facades

--- a/src/Monitor/Services/TreblleMonitoring.php
+++ b/src/Monitor/Services/TreblleMonitoring.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\Monitor\Services;
+
+use Carbon\Carbon;
+use Treblle\Laravel\Config\Validator;
+use Treblle\Laravel\Jobs\SendTreblleData;
+use Treblle\Laravel\Exceptions\TreblleException;
+use Treblle\Laravel\Factories\PayloadDataFactory;
+use Treblle\Laravel\Monitor\DataTransferObjects\MonitoringData;
+
+/**
+ * Service for proving monitoring, for third party API's.
+ *
+ * This service can be used to monitor calls to third party API's called from the system
+ * I does not include any request or response data coming from third party API's
+ * I relais only on response http code and configuration from treblle config file
+ *
+ * It will monitor following:
+ *  - Number of success or failed calls
+ *  - Response status codes
+ *  - Total execution time of the request
+ *  - Activity of third party api's
+ *
+ * @package Treblle\Laravel\Monitor\Services
+ */
+final class TreblleMonitoring
+{
+    private bool $queueEnabled;
+
+    private ?string $queueConnection;
+
+    private string $queueName;
+
+    public function __construct(
+        private readonly Validator $configValidator
+    ) {
+        $this->queueEnabled = (bool) config('treblle.queue.enabled', false);
+        $this->queueConnection = config('treblle.queue.connection');
+        $this->queueName = config('treblle.queue.queue', 'default');
+    }
+
+    /**
+     * Method to be called to monitor third party api
+     * Transmits data to Treblle endpoints
+     */
+    public function monitor(string|int $statusCode, string|int $apiId, string|int $endpointId): void
+    {
+        try {
+            $this->configValidator->validateEnvironment();
+        } catch (TreblleException) {
+            return;
+        }
+
+        try {
+            $this->configValidator->validateKeys();
+        } catch (TreblleException) {
+            return;
+        }
+
+        if ($this->queueEnabled) {
+            $this->dispatchToQueue($statusCode, $apiId, $endpointId);
+
+            return;
+        }
+
+        $this->sendSync();
+    }
+
+    /**
+     * Uses Laravel Queue channels to transmit third party API's monitoring data
+     */
+    private function dispatchToQueue(string|int $statusCode, string|int $apiId, string|int $endpointId): void
+    {
+        try {
+            $monitoringPayloadData = PayloadDataFactory::create(PayloadDataFactory::MONITORING);
+        } catch (TreblleException) {
+            return;
+        }
+
+        $monitoringPayloadData->setData(new MonitoringData(
+            statusCode: is_int($statusCode) ? $statusCode : (int) $statusCode,
+            time: Carbon::now()->timestamp,
+            duration: 0,
+            apiId: is_string($apiId) ? $apiId : (string) $apiId,
+            endpointId: is_string($endpointId) ? $endpointId : (string) $endpointId,
+            config: config('treblle.monitoring') ?? [],
+        ));
+
+        // Create and dispatch job with serializable data
+        $job = new SendTreblleData($monitoringPayloadData);
+
+        if ($this->queueConnection) {
+            $job->onConnection($this->queueConnection);
+        }
+
+        $job->onQueue($this->queueName);
+
+        dispatch($job);
+    }
+
+    /**
+     * Transmits theirs party aPI's monitoring data synchronously
+     *
+     * NOTE: Not implemented at this time. It requires modification of treblle-php sdk
+     */
+    private function sendSync(): void {}
+}

--- a/src/Monitor/Services/TreblleMonitoring.php
+++ b/src/Monitor/Services/TreblleMonitoring.php
@@ -6,9 +6,9 @@ namespace Treblle\Laravel\Monitor\Services;
 
 use Carbon\Carbon;
 use Treblle\Laravel\Config\Validator;
-use Treblle\Laravel\Jobs\SendTreblleData;
 use Treblle\Laravel\Exceptions\TreblleException;
 use Treblle\Laravel\Factories\PayloadDataFactory;
+use Treblle\Laravel\Jobs\SendTreblleData;
 use Treblle\Laravel\Monitor\DataTransferObjects\MonitoringData;
 
 /**
@@ -34,7 +34,7 @@ final class TreblleMonitoring
 
     private ?int $monitoringStartTime = null;
 
-    private ?int $monitoringTotalTime = null;
+    private ?int $monitoringTotalTime = 0;
 
     public function __construct(
         private readonly Validator $configValidator
@@ -58,8 +58,6 @@ final class TreblleMonitoring
     public function stopWatchEnd(): self
     {
         if (null === $this->monitoringStartTime) {
-            $this->monitoringTotalTime = 0;
-
             return $this;
         }
 
@@ -133,7 +131,7 @@ final class TreblleMonitoring
     {
         $totalTime = $this->monitoringTotalTime;
 
-        $this->monitoringTotalTime = null;
+        $this->monitoringTotalTime = 0;
 
         return $totalTime;
     }

--- a/src/Monitor/Services/TreblleMonitoring.php
+++ b/src/Monitor/Services/TreblleMonitoring.php
@@ -139,7 +139,7 @@ final class TreblleMonitoring
     }
 
     /**
-     * Transmits theirs party aPI's monitoring data synchronously
+     * Transmits third party API's monitoring data synchronously
      *
      * NOTE: Not implemented at this time. It requires modification of treblle-php sdk
      */

--- a/src/Monitor/Services/TreblleMonitoring.php
+++ b/src/Monitor/Services/TreblleMonitoring.php
@@ -23,8 +23,6 @@ use Treblle\Laravel\Monitor\DataTransferObjects\MonitoringData;
  *  - Response status codes
  *  - Total execution time of the request
  *  - Activity of third party api's
- *
- * @package Treblle\Laravel\Monitor\Services
  */
 final class TreblleMonitoring
 {
@@ -34,12 +32,42 @@ final class TreblleMonitoring
 
     private string $queueName;
 
+    private ?int $monitoringStartTime = null;
+
+    private ?int $monitoringTotalTime = null;
+
     public function __construct(
         private readonly Validator $configValidator
     ) {
         $this->queueEnabled = (bool) config('treblle.queue.enabled', false);
         $this->queueConnection = config('treblle.queue.connection');
         $this->queueName = config('treblle.queue.queue', 'default');
+    }
+
+    /**
+     * Can be used before third party API call to monitor execution time
+     */
+    public function stopWatchStart(): void
+    {
+        $this->monitoringStartTime = Carbon::now()->timestamp;
+    }
+
+    /**
+     * If stopWatchStart was used, it will calculate total execution time, else 0 is returned
+     */
+    public function stopWatchEnd(): self
+    {
+        if (null === $this->monitoringStartTime) {
+            $this->monitoringTotalTime = 0;
+
+            return $this;
+        }
+
+        $this->monitoringTotalTime = Carbon::now()->timestamp - $this->monitoringStartTime;
+
+        $this->monitoringStartTime = null;
+
+        return $this;
     }
 
     /**
@@ -83,7 +111,7 @@ final class TreblleMonitoring
         $monitoringPayloadData->setData(new MonitoringData(
             statusCode: is_int($statusCode) ? $statusCode : (int) $statusCode,
             time: Carbon::now()->timestamp,
-            duration: 0,
+            duration: $this->getMonitoringTotalTime(),
             apiId: is_string($apiId) ? $apiId : (string) $apiId,
             endpointId: is_string($endpointId) ? $endpointId : (string) $endpointId,
             config: config('treblle.monitoring') ?? [],
@@ -99,6 +127,15 @@ final class TreblleMonitoring
         $job->onQueue($this->queueName);
 
         dispatch($job);
+    }
+
+    private function getMonitoringTotalTime(): int
+    {
+        $totalTime = $this->monitoringTotalTime;
+
+        $this->monitoringTotalTime = null;
+
+        return $totalTime;
     }
 
     /**


### PR DESCRIPTION
- This is only concept of feature that would monitor third party APIs, that are used by API, which uses SDK
- Proposed is additional feature that allows users not only to monitor performance on their own APIs, but also integrations with third party APIs, only on smaller scale
- Non of request/response data is transmitted, only status code from third party API calls, is used 

Following can be monitored:
 - Number of successful/failed requests
 - Status code and distribution by endpoints and status codes
 - Time when request was executed
 - Duration of request execution
 - Third party API activity and frequency of usage

Existing Treblle APIs probably could not be used, since data part of payload differs greatly from original one
Sync transmission is not developed, it would require modification of base treblle-php SDK, and since this is only a concept, that modification is not necessary at this time,