### PR TITLE
Fix file upload requests not being logged on Treblle

### DIFF
--- a/src/DataProviders/LaravelRequestDataProvider.php
+++ b/src/DataProviders/LaravelRequestDataProvider.php
@@ -72,21 +72,26 @@ final readonly class LaravelRequestDataProvider implements RequestDataProvider
      */
     private function getRawBody(): array
     {
-        // Use original payload captured by TreblleEarlyMiddleware if available
+        // TreblleEarlyMiddleware captures both text fields and file metadata at request
+        // start — before any controller can move/delete uploaded files. Use it as-is.
         if ($this->request->attributes->has('treblle_original_payload')) {
-            $payload = $this->request->attributes->get('treblle_original_payload');
-        } else {
-            try {
-                $payload = $this->request->input();
-            } catch (Throwable) {
-                $payload = [];
-            }
+            return $this->request->attributes->get('treblle_original_payload');
         }
 
-        // Merge in file metadata from the actual files bag
+        // Fallback when early middleware did not run.
+        try {
+            $payload = $this->request->input();
+        } catch (Throwable) {
+            $payload = [];
+        }
+
         if ($this->request instanceof \Illuminate\Http\Request) {
             foreach ($this->request->files->all() as $key => $file) {
-                $payload[$key] = $this->normalizeFile($file);
+                try {
+                    $payload[$key] = $this->normalizeFile($file);
+                } catch (Throwable) {
+                    // File may have been moved/deleted by the controller; skip
+                }
             }
         }
 

--- a/src/Middlewares/TreblleEarlyMiddleware.php
+++ b/src/Middlewares/TreblleEarlyMiddleware.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Treblle\Laravel\Middlewares;
 
 use Closure;
+use Throwable;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 
 /**
  * Early Capture Middleware for Treblle Monitoring.
@@ -40,8 +42,32 @@ final class TreblleEarlyMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
-        $request->attributes->set('treblle_original_payload', $request->input());
+        $payload = $request->input();
+
+        foreach ($request->files->all() as $key => $file) {
+            try {
+                $payload[$key] = $this->normalizeFile($file);
+            } catch (Throwable) {
+                // Skip files that can't be read (should not happen at request start)
+            }
+        }
+
+        $request->attributes->set('treblle_original_payload', $payload);
 
         return $next($request);
+    }
+
+    private function normalizeFile(UploadedFile|array $file): array
+    {
+        if (is_array($file)) {
+            return array_map([$this, 'normalizeFile'], $file);
+        }
+
+        return [
+            'name'      => $file->getClientOriginalName(),
+            'size'      => $file->getSize(),
+            'mime_type' => $file->getMimeType() ?? $file->getClientMimeType(),
+            'extension' => $file->getClientOriginalExtension(),
+        ];
     }
 }

--- a/tests/Feature/DataProviders/LaravelRequestDataProviderTest.php
+++ b/tests/Feature/DataProviders/LaravelRequestDataProviderTest.php
@@ -113,6 +113,28 @@ final class LaravelRequestDataProviderTest extends TestCase
         $this->assertSame('captured-before-transform', $serialized['body']['original']);
     }
 
+    public function test_uses_file_metadata_from_early_payload(): void
+    {
+        // Simulate TreblleEarlyMiddleware having already captured file metadata.
+        // Files added to $request->files AFTER the early capture should not overwrite
+        // the early-captured data — this is the key correctness guarantee.
+        $request = Request::create('http://localhost/api/upload', 'POST');
+        $request->attributes->set('treblle_original_payload', [
+            'attachment' => [
+                'name'      => 'early-captured.pdf',
+                'size'      => 1024,
+                'mime_type' => 'application/pdf',
+                'extension' => 'pdf',
+            ],
+        ]);
+
+        $provider = new LaravelRequestDataProvider(new SensitiveDataMasker(), $request);
+        $serialized = $provider->getRequest()->jsonSerialize();
+
+        $this->assertSame('early-captured.pdf', $serialized['body']['attachment']['name']);
+        $this->assertSame(1024, $serialized['body']['attachment']['size']);
+    }
+
     public function test_request_body_too_large_returns_error(): void
     {
         // Create a body that exceeds 2MB

--- a/tests/Feature/Middlewares/TreblleEarlyMiddlewareTest.php
+++ b/tests/Feature/Middlewares/TreblleEarlyMiddlewareTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Treblle\Laravel\Tests\Feature\Middlewares;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Treblle\Laravel\Tests\TestCase;
 use Treblle\Laravel\Middlewares\TreblleEarlyMiddleware;
 
@@ -65,5 +66,43 @@ final class TreblleEarlyMiddlewareTest extends TestCase
         $result = $middleware->handle($request, fn ($req) => $expectedResponse);
 
         $this->assertSame($expectedResponse, $result);
+    }
+
+    public function test_captures_file_metadata_in_payload(): void
+    {
+        $request = Request::create('http://localhost/api/upload', 'POST', ['title' => 'Report']);
+        $file = UploadedFile::fake()->create('report.pdf', 200, 'application/pdf');
+        $request->files->set('attachment', $file);
+
+        $middleware = new TreblleEarlyMiddleware();
+        $middleware->handle($request, fn ($req) => response('ok'));
+
+        $payload = $request->attributes->get('treblle_original_payload');
+
+        $this->assertSame('Report', $payload['title']);
+        $this->assertSame('report.pdf', $payload['attachment']['name']);
+        $this->assertSame('pdf', $payload['attachment']['extension']);
+        $this->assertArrayHasKey('size', $payload['attachment']);
+        $this->assertArrayHasKey('mime_type', $payload['attachment']);
+    }
+
+    public function test_captures_multiple_file_uploads(): void
+    {
+        $request = Request::create('http://localhost/api/upload', 'POST');
+        $files = [
+            UploadedFile::fake()->create('a.jpg', 50, 'image/jpeg'),
+            UploadedFile::fake()->create('b.jpg', 60, 'image/jpeg'),
+        ];
+        $request->files->set('images', $files);
+
+        $middleware = new TreblleEarlyMiddleware();
+        $middleware->handle($request, fn ($req) => response('ok'));
+
+        $payload = $request->attributes->get('treblle_original_payload');
+
+        $this->assertIsArray($payload['images']);
+        $this->assertCount(2, $payload['images']);
+        $this->assertSame('a.jpg', $payload['images'][0]['name']);
+        $this->assertSame('b.jpg', $payload['images'][1]['name']);
     }
 }


### PR DESCRIPTION
TreblleEarlyMiddleware only captured text fields via $request->input(),
leaving file metadata to be collected later in LaravelRequestDataProvider::getRawBody()
at terminate() time — after the response is sent. When a controller called
$file->move(), the temp file was deleted before terminate() ran. The subsequent
$file->getSize() call threw RuntimeException("stat failed for /tmp/phpXXXX"),
which propagated up and was silently swallowed, causing the entire request to
be dropped from Treblle.

Fix: capture file metadata (name, size, mime_type, extension) in
TreblleEarlyMiddleware at request start, before any controller can move files.
LaravelRequestDataProvider now returns this early payload as-is instead of
re-iterating files post-response. A per-file try/catch is added to the fallback
path (when early middleware is absent) as a safety net.

https://claude.ai/code/session_015mrP7j7dniGAZZNapYEbcb