### PR TITLE
File Upload Handler

### DIFF
--- a/src/DataProviders/LaravelRequestDataProvider.php
+++ b/src/DataProviders/LaravelRequestDataProvider.php
@@ -86,7 +86,11 @@ final readonly class LaravelRequestDataProvider implements RequestDataProvider
         // Merge in file metadata from the actual files bag
         if ($this->request instanceof \Illuminate\Http\Request) {
             foreach ($this->request->files->all() as $key => $file) {
-                $payload[$key] = $this->normalizeFile($file);
+                try {
+                    $payload[$key] = $this->normalizeFile($file);
+                } catch (\Throwable) {
+                    $payload[$key] = ['error' => 'file metadata unavailable'];
+                }
             }
         }
 


### PR DESCRIPTION
  Fixes a silent request capture failure for file upload endpoints. When TreblleMiddleware::terminate() runs after a multipart/form-data
  request, it calls $file->getMimeType() via normalizeFile() to extract file metadata. Symfony's FileBinaryMimeTypeGuesser throws
  InvalidArgumentException if the temp file is not accessible at that point — and because the file iteration loop had no try/catch, the
  exception propagated up and was swallowed silently in sendSynchronously(), causing the entire request to never appear in Treblle. Wraps
  the normalizeFile() call in a try/catch so the request is still captured with a {'error': 'file metadata unavailable'} placeholder for
  the file field instead of being dropped.

  Type of change

  - Bug fix

  Checklist

  - Tests pass locally (./vendor/bin/phpunit)
  - Code style passes (./vendor/bin/pint --test)
  - CHANGELOG.md updated under [Unreleased]
  - Relevant documentation updated (README, config comments)

  Related issues