### PR TITLE
Add Octane Support to SQL Query capture

### DIFF
--- a/src/TreblleServiceProvider.php
+++ b/src/TreblleServiceProvider.php
@@ -84,7 +84,7 @@ final class TreblleServiceProvider extends ServiceProvider
         $events->listen(QueryExecuted::class, function (QueryExecuted $event): void {
             try {
                 /** @var QueryCollector $collector */
-                $collector = $this->app->make(QueryCollector::class);
+                $collector = app(QueryCollector::class);
                 $collector->record($event->sql, $event->time ?? 0.0);
             } catch (Throwable) {
                 // Silently ignore — query collection must never break the app


### PR DESCRIPTION
  SQL queries were captured correctly in standard Laravel but the queries array arrived empty when running under Laravel Octane.

  Octane handles each request in a cloned "sandbox" container. Scoped bindings (like QueryCollector) are resolved fresh per-request
  inside that sandbox. The QueryExecuted event listener was registered once at boot using $this->app — a reference to the parent
  container captured at service provider instantiation. Octane never touches this container during request handling, so queries were
  recorded into the parent's QueryCollector instance.