### PR TITLE
feat: add support for SSE & streamed responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,47 @@ Headers listed in `excluded_headers` are completely removed from the data sent t
 
 ---
 
+### Streamed & SSE Responses
+
+Treblle captures streamed responses — `response()->stream()`,
+`response()->eventStream()` (Server-Sent Events), and `response()->streamJson()`.
+Because these responses generate their body from a callback while it is sent to
+the client, the SDK tees the streamed output into a buffer as it flows (without
+affecting real-time delivery) and includes it in the payload.
+
+For SSE responses (`Content-Type: text/event-stream`), the body is parsed into a
+structured list of events, e.g.:
+
+```json
+"body": [
+    { "id": "1", "event": "message", "data": { "token": "Hello" } },
+    { "id": "2", "event": "message", "data": { "token": " world" } }
+]
+```
+
+Event `data` is JSON-decoded when it is valid JSON, otherwise kept as a string.
+Sensitive-field masking still applies to the parsed `data`.
+
+**Things to know:**
+
+- **Reporting happens when the stream closes.** Treblle transmits after the
+  response finishes (Laravel's terminable phase), so a stream is reported once it
+  completes. A **truly infinite** SSE connection that never closes is never
+  reported.
+- **`load_time` covers the whole stream.** For a streamed response, load time
+  reflects the full connection duration by design.
+- **Capture is capped at 2MB.** Longer streams are truncated in the captured
+  body and an error is recorded on the request in Treblle (real-time delivery to
+  the client is unaffected).
+- **Force-clearing output buffers defeats capture.** If your stream callback
+  runs `while (ob_get_level()) { ob_end_flush(); }`, it removes Treblle's tee
+  buffer and the body will not be captured.
+- **Octane:** streamed-body capture is validated on the standard FPM/CLI SAPIs.
+  Behavior under Laravel Octane (Swoole/RoadRunner), where output handling
+  differs, has not been verified.
+
+---
+
 ### Debug Mode
 
 Enable debug mode to log Treblle warnings and errors to your Laravel log file:

--- a/src/DataProviders/LaravelResponseDataProvider.php
+++ b/src/DataProviders/LaravelResponseDataProvider.php
@@ -8,10 +8,13 @@ use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Treblle\Laravel\Helpers\HeaderFilter;
 use Treblle\Laravel\DataTransferObject\Error;
+use Treblle\Laravel\Helpers\EventStreamParser;
 use Treblle\Laravel\Contracts\ErrorDataProvider;
 use Treblle\Laravel\DataTransferObject\Response;
 use Treblle\Laravel\Helpers\SensitiveDataMasker;
 use Treblle\Laravel\Contracts\ResponseDataProvider;
+use Treblle\Laravel\Helpers\StreamedResponseCapture;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
@@ -36,8 +39,21 @@ final class LaravelResponseDataProvider implements ResponseDataProvider
 
     public function getResponse(): Response
     {
-        $rawBody = $this->response->getContent() ?: '{}';
+        $capture = $this->streamedCapture();
+        $streamed = $this->isStreamed();
+        $rawBody = $this->resolveRawBody($capture);
         $size = strlen($rawBody);
+
+        // A streamed body that hit the capture limit is reported like the
+        // oversize case so the truncation is visible in Treblle.
+        if (null !== $capture && $capture->isTruncated()) {
+            $this->errorDataProvider->addError(new Error(
+                message: 'Streamed response truncated at capture limit',
+                file: '',
+                line: 0,
+                type: 'E_USER_WARNING',
+            ));
+        }
 
         // Enforce 2MB limit before decoding to avoid processing a huge string
         if ($size > 2 * 1024 * 1024) {
@@ -50,15 +66,105 @@ final class LaravelResponseDataProvider implements ResponseDataProvider
 
             $rawBody = (string) json_encode(['error' => 'Payload too large', 'size' => $size]);
             $size = strlen($rawBody);
+
+            return $this->buildResponse($size, $this->fieldMasker->mask((array) json_decode($rawBody, true)));
         }
 
+        return $this->buildResponse($size, $this->fieldMasker->mask($this->decodeBody($rawBody, $streamed)));
+    }
+
+    /**
+     * Whether the underlying response streams its body from a callback.
+     */
+    private function isStreamed(): bool
+    {
+        return $this->response instanceof StreamedResponse;
+    }
+
+    /**
+     * The capture holder the middleware teed the streamed output into, if any.
+     */
+    private function streamedCapture(): ?StreamedResponseCapture
+    {
+        if (! $this->isStreamed()) {
+            return null;
+        }
+
+        $capture = $this->request->attributes->get('treblle_streamed_capture');
+
+        return $capture instanceof StreamedResponseCapture ? $capture : null;
+    }
+
+    /**
+     * Resolve the raw response body.
+     *
+     * Streamed responses (stream, eventStream/SSE, streamJson) return false from
+     * getContent(), so their body is read from the capture holder that the
+     * middleware teed the streamed output into.
+     */
+    private function resolveRawBody(?StreamedResponseCapture $capture): string
+    {
+        if (null !== $capture) {
+            return $capture->getContent() ?: '{}';
+        }
+
+        return $this->response->getContent() ?: '{}';
+    }
+
+    /**
+     * Decode the raw body into the array stored in the payload.
+     *
+     * SSE bodies are parsed into a structured events array; everything else is
+     * JSON-decoded (covering streamJson and standard JSON responses). Non-JSON
+     * streamed bodies fall back to a raw string wrapper so streamed text is not
+     * silently discarded.
+     *
+     * @return array<int|string, mixed>
+     */
+    private function decodeBody(string $rawBody, bool $streamed): array
+    {
+        // '{}' is the empty-body sentinel from resolveRawBody(); treat as no body.
+        if ('' === $rawBody || '{}' === $rawBody) {
+            return [];
+        }
+
+        if ($streamed && $this->isEventStream()) {
+            return EventStreamParser::parse($rawBody);
+        }
+
+        $decoded = json_decode($rawBody, true);
+
+        if (is_array($decoded)) {
+            return $decoded;
+        }
+
+        if ($streamed && '{}' !== $rawBody) {
+            return ['raw' => $rawBody];
+        }
+
+        return [];
+    }
+
+    /**
+     * Whether the response advertises the SSE (text/event-stream) content type.
+     */
+    private function isEventStream(): bool
+    {
+        $contentType = $this->response->headers->get('Content-Type', '');
+
+        return str_contains(strtolower((string) $contentType), 'text/event-stream');
+    }
+
+    /**
+     * @param array<int|string, mixed> $body
+     */
+    private function buildResponse(int $size, array $body): Response
+    {
         return new Response(
             code: $this->response->getStatusCode(),
             size: $size,
             load_time: $this->getLoadTimeInMilliseconds(),
-            body: $this->fieldMasker->mask(
-                json_decode($rawBody, true) ?? []
-            ),
+            body: $body,
             headers: $this->fieldMasker->mask(
                 HeaderFilter::filter($this->response->headers->all(), config('treblle.excluded_headers', []))
             ),

--- a/src/DataProviders/LaravelResponseDataProvider.php
+++ b/src/DataProviders/LaravelResponseDataProvider.php
@@ -44,11 +44,14 @@ final class LaravelResponseDataProvider implements ResponseDataProvider
         $rawBody = $this->resolveRawBody($capture);
         $size = strlen($rawBody);
 
-        // A streamed body that hit the capture limit is reported like the
-        // oversize case so the truncation is visible in Treblle.
+        // A streamed body that stopped growing early is reported so the
+        // truncation is visible in Treblle. The reason distinguishes the
+        // per-stream 2MB cap from the shared memory budget being exhausted.
         if (null !== $capture && $capture->isTruncated()) {
             $this->errorDataProvider->addError(new Error(
-                message: 'Streamed response truncated at capture limit',
+                message: 'memory_budget' === $capture->reason()
+                    ? 'Streamed response body not fully captured (memory budget reached)'
+                    : 'Streamed response truncated at capture limit',
                 file: '',
                 line: 0,
                 type: 'E_USER_WARNING',

--- a/src/Helpers/EventStreamParser.php
+++ b/src/Helpers/EventStreamParser.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\Helpers;
+
+/**
+ * Parses a raw Server-Sent Events (text/event-stream) body into structured events.
+ *
+ * Follows the SSE wire format: events are separated by a blank line, each event
+ * is a set of `field: value` lines (id, event, data, retry), lines starting with
+ * a colon are comments, and multiple `data:` lines are joined with a newline.
+ * Each event's data is JSON-decoded when it is valid JSON, otherwise kept as a
+ * string.
+ *
+ * @phpstan-type StreamedEvent array{id?: string, event?: string, retry?: int, data: mixed}
+ */
+final class EventStreamParser
+{
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public static function parse(string $raw): array
+    {
+        if ('' === trim($raw)) {
+            return [];
+        }
+
+        $normalized = str_replace(["\r\n", "\r"], "\n", $raw);
+        $blocks = preg_split('/\n\n+/', $normalized) ?: [];
+
+        $events = [];
+
+        foreach ($blocks as $block) {
+            $event = self::parseBlock($block);
+
+            if (null !== $event) {
+                $events[] = $event;
+            }
+        }
+
+        return $events;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private static function parseBlock(string $block): ?array
+    {
+        $id = null;
+        $eventName = null;
+        $retry = null;
+        $dataLines = [];
+        $hasField = false;
+
+        foreach (explode("\n", $block) as $line) {
+            if ('' === $line || str_starts_with($line, ':')) {
+                continue; // blank line or comment
+            }
+
+            $hasField = true;
+
+            [$field, $value] = self::splitLine($line);
+
+            switch ($field) {
+                case 'id':
+                    $id = $value;
+
+                    break;
+                case 'event':
+                    $eventName = $value;
+
+                    break;
+                case 'retry':
+                    $retry = ctype_digit($value) ? (int) $value : null;
+
+                    break;
+                case 'data':
+                    $dataLines[] = $value;
+
+                    break;
+            }
+        }
+
+        if (! $hasField) {
+            return null;
+        }
+
+        $event = [];
+
+        if (null !== $id) {
+            $event['id'] = $id;
+        }
+
+        if (null !== $eventName) {
+            $event['event'] = $eventName;
+        }
+
+        if (null !== $retry) {
+            $event['retry'] = $retry;
+        }
+
+        $event['data'] = self::decodeData(implode("\n", $dataLines));
+
+        return $event;
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private static function splitLine(string $line): array
+    {
+        $colon = strpos($line, ':');
+
+        if (false === $colon) {
+            // A line with no colon is a field name with an empty value.
+            return [$line, ''];
+        }
+
+        $field = substr($line, 0, $colon);
+        $value = substr($line, $colon + 1);
+
+        // A single leading space after the colon is stripped per the SSE spec.
+        if (str_starts_with($value, ' ')) {
+            $value = substr($value, 1);
+        }
+
+        return [$field, $value];
+    }
+
+    private static function decodeData(string $data): mixed
+    {
+        if ('' === $data) {
+            return '';
+        }
+
+        $decoded = json_decode($data, true);
+
+        return JSON_ERROR_NONE === json_last_error() ? $decoded : $data;
+    }
+}

--- a/src/Helpers/StreamCaptureBudget.php
+++ b/src/Helpers/StreamCaptureBudget.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\Helpers;
+
+/**
+ * Process-wide memory budget shared by all in-flight stream captures.
+ *
+ * Each streamed response reserves bytes from this budget as its capture buffer
+ * grows, and releases them when the stream ends. Once the budget is exhausted,
+ * further streams are still monitored (status/headers/timing) but stop copying
+ * their body — bounding total stream-capture memory regardless of how many
+ * streams run concurrently (the risk under async runtimes such as Octane/Swoole).
+ *
+ * Bound as a container singleton so it is shared across the concurrent requests
+ * of one Octane worker. Under FPM it resets per request (harmless), under
+ * RoadRunner/FrankenPHP it persists per worker/thread (so reliable release is
+ * essential — see StreamedResponseCapture::releaseBudget()).
+ *
+ * Soft limit: on a truly multithreaded runtime a race could nudge the counter
+ * slightly over the max, which is harmless for a memory guard. Under Swoole
+ * (cooperative, single-thread per worker) and the CLI it is exact.
+ */
+final class StreamCaptureBudget
+{
+    /** Total bytes allowed across all concurrent stream captures per process. */
+    public const MAX = 32 * 1024 * 1024;
+
+    private int $used = 0;
+
+    /**
+     * @param int $max Ceiling in bytes. Defaults to the hardcoded MAX; the
+     *                 argument exists only as an internal test seam, not config.
+     */
+    public function __construct(
+        private readonly int $max = self::MAX,
+    ) {
+    }
+
+    /**
+     * Reserve $bytes if they fit within the remaining budget.
+     *
+     * @return bool true if reserved, false if it would exceed the budget
+     */
+    public function tryReserve(int $bytes): bool
+    {
+        if ($this->used + $bytes > $this->max) {
+            return false;
+        }
+
+        $this->used += $bytes;
+
+        return true;
+    }
+
+    /**
+     * Return previously reserved bytes to the budget (floored at zero).
+     */
+    public function release(int $bytes): void
+    {
+        $this->used = max(0, $this->used - $bytes);
+    }
+
+    /**
+     * Bytes currently reserved across all live captures.
+     */
+    public function used(): int
+    {
+        return $this->used;
+    }
+}

--- a/src/Helpers/StreamedResponseCapture.php
+++ b/src/Helpers/StreamedResponseCapture.php
@@ -25,8 +25,20 @@ final class StreamedResponseCapture
 
     private bool $truncated = false;
 
+    /**
+     * Bytes reserved from the shared budget so far. Must always equal the number
+     * of bytes we handed to StreamCaptureBudget::tryReserve() and kept, so that
+     * releaseBudget() returns exactly what was taken. Diverging here silently
+     * drifts the process-wide budget (see releaseBudget()).
+     */
+    private int $reserved = 0;
+
+    /** Why capture stopped growing: 'stream_limit' (2MB) or 'memory_budget'. */
+    private ?string $reason = null;
+
     public function __construct(
         private readonly int $limit = self::DEFAULT_LIMIT,
+        private readonly ?StreamCaptureBudget $budget = null,
     ) {
     }
 
@@ -36,16 +48,40 @@ final class StreamedResponseCapture
             return;
         }
 
+        // 1. Per-stream 2MB cap: shorten the chunk to what fits, if needed.
         $remaining = $this->limit - strlen($this->content);
 
         if (strlen($chunk) >= $remaining) {
-            $this->content .= substr($chunk, 0, max($remaining, 0));
+            $chunk = substr($chunk, 0, max($remaining, 0));
             $this->truncated = true;
+            $this->reason ??= 'stream_limit';
+        }
+
+        if ('' === $chunk) {
+            return;
+        }
+
+        // 2. Shared memory budget: reserve exactly the (already-capped) size we
+        // intend to keep. If it doesn't fit, stop capturing this stream's body.
+        if (null !== $this->budget && ! $this->budget->tryReserve(strlen($chunk))) {
+            $this->truncated = true;
+            $this->reason ??= 'memory_budget';
 
             return;
         }
 
         $this->content .= $chunk;
+        $this->reserved += strlen($chunk);
+    }
+
+    /**
+     * Return this capture's reserved bytes to the shared budget. Idempotent so it
+     * is safe to call once in the middleware's guaranteed finally block.
+     */
+    public function releaseBudget(): void
+    {
+        $this->budget?->release($this->reserved);
+        $this->reserved = 0;
     }
 
     public function getContent(): string
@@ -56,5 +92,10 @@ final class StreamedResponseCapture
     public function isTruncated(): bool
     {
         return $this->truncated;
+    }
+
+    public function reason(): ?string
+    {
+        return $this->reason;
     }
 }

--- a/src/Helpers/StreamedResponseCapture.php
+++ b/src/Helpers/StreamedResponseCapture.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\Helpers;
+
+/**
+ * Accumulates the body of a streamed response as it is sent to the client.
+ *
+ * A Symfony StreamedResponse produces its body from a callback during send, so
+ * Response::getContent() returns false and Treblle has nothing to capture in
+ * terminate(). This holder is shared (by reference) between the wrapped stream
+ * callback (which tees each chunk into append()) and the response data provider
+ * (which reads getContent() when building the payload).
+ *
+ * Accumulation is capped to protect memory on long-running streams; once the cap
+ * is reached further chunks are dropped and the capture is flagged as truncated.
+ */
+final class StreamedResponseCapture
+{
+    /** Matches the 2MB response body limit enforced in LaravelResponseDataProvider. */
+    private const DEFAULT_LIMIT = 2 * 1024 * 1024;
+
+    private string $content = '';
+
+    private bool $truncated = false;
+
+    public function __construct(
+        private readonly int $limit = self::DEFAULT_LIMIT,
+    ) {
+    }
+
+    public function append(string $chunk): void
+    {
+        if ($this->truncated) {
+            return;
+        }
+
+        $remaining = $this->limit - strlen($this->content);
+
+        if (strlen($chunk) >= $remaining) {
+            $this->content .= substr($chunk, 0, max($remaining, 0));
+            $this->truncated = true;
+
+            return;
+        }
+
+        $this->content .= $chunk;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function isTruncated(): bool
+    {
+        return $this->truncated;
+    }
+}

--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -153,6 +153,10 @@ final class TreblleMiddleware
         $request->attributes->set('treblle_streamed_capture', $capture);
 
         $response->setCallback(static function () use ($original, $capture): void {
+            // Remember the buffer depth before we add ours so we only ever tear
+            // down buffers we are responsible for, never a pre-existing one.
+            $baseLevel = ob_get_level();
+
             // chunk_size = 1 flushes the handler on every write, so the client
             // still receives chunks incrementally while we tee a copy.
             ob_start(static function (string $chunk) use ($capture): string {
@@ -164,8 +168,15 @@ final class TreblleMiddleware
             try {
                 $original();
             } finally {
-                if (ob_get_level() > 0) {
-                    ob_end_flush();
+                // Flush and close our buffer plus any the callback left open on
+                // top of it. If the callback already tore ours down (e.g. it ran
+                // its own `while (ob_get_level()) ob_end_flush()`), the level is
+                // at or below $baseLevel and this loop is a no-op, so we never
+                // close a buffer that existed before us.
+                while (ob_get_level() > $baseLevel) {
+                    if (! ob_end_flush()) {
+                        break; // non-removable buffer; avoid an infinite loop
+                    }
                 }
             }
         });

--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -15,7 +15,9 @@ use Treblle\Laravel\TreblleServiceProvider;
 use Treblle\Laravel\DataTransferObject\Data;
 use Treblle\Laravel\DataTransferObject\Error;
 use Treblle\Laravel\Helpers\SensitiveDataMasker;
+use Treblle\Laravel\Helpers\StreamedResponseCapture;
 use Treblle\Laravel\DataProviders\ServerDataProvider;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Treblle\Laravel\DataProviders\LanguageDataProvider;
 use Treblle\Laravel\DataTransferObject\TrebllePayloadData;
 use Treblle\Laravel\DataProviders\InMemoryErrorDataProvider;
@@ -84,7 +86,11 @@ final class TreblleMiddleware
             return $next($request);
         }
 
-        return $next($request);
+        $response = $next($request);
+
+        $this->wrapStreamedResponse($request, $response);
+
+        return $response;
     }
 
     /**
@@ -115,6 +121,54 @@ final class TreblleMiddleware
         }
 
         $this->sendSynchronously($request, $response, $apiKey);
+    }
+
+    /**
+     * Tee a streamed response body into a capture holder as it is sent.
+     *
+     * Streamed responses (stream, eventStream/SSE, streamJson) generate their
+     * body from a callback during send, so getContent() returns false and there
+     * is nothing to capture in terminate(). We wrap the callback with a
+     * pass-through output buffer that copies each chunk into a holder stored on
+     * the request, which the response data provider reads when building the
+     * payload. The chunk is returned unchanged so real-time streaming to the
+     * client is preserved.
+     *
+     * This must never throw — it honors the middleware's "never break the app"
+     * contract via the instanceof and null-callback guards.
+     */
+    private function wrapStreamedResponse(Request $request, mixed $response): void
+    {
+        if (! $response instanceof StreamedResponse) {
+            return;
+        }
+
+        $original = $response->getCallback();
+
+        if (null === $original) {
+            return;
+        }
+
+        $capture = new StreamedResponseCapture();
+        $request->attributes->set('treblle_streamed_capture', $capture);
+
+        $response->setCallback(static function () use ($original, $capture): void {
+            // chunk_size = 1 flushes the handler on every write, so the client
+            // still receives chunks incrementally while we tee a copy.
+            ob_start(static function (string $chunk) use ($capture): string {
+                $capture->append($chunk);
+
+                return $chunk;
+            }, 1);
+
+            try {
+                $original();
+            } finally {
+                if (ob_get_level() > 0) {
+                    ob_end_flush();
+                }
+            }
+        });
     }
 
     /**

--- a/src/Middlewares/TreblleMiddleware.php
+++ b/src/Middlewares/TreblleMiddleware.php
@@ -15,6 +15,7 @@ use Treblle\Laravel\TreblleServiceProvider;
 use Treblle\Laravel\DataTransferObject\Data;
 use Treblle\Laravel\DataTransferObject\Error;
 use Treblle\Laravel\Helpers\SensitiveDataMasker;
+use Treblle\Laravel\Helpers\StreamCaptureBudget;
 use Treblle\Laravel\Helpers\StreamedResponseCapture;
 use Treblle\Laravel\DataProviders\ServerDataProvider;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -149,7 +150,9 @@ final class TreblleMiddleware
             return;
         }
 
-        $capture = new StreamedResponseCapture();
+        $capture = new StreamedResponseCapture(
+            budget: app(StreamCaptureBudget::class),
+        );
         $request->attributes->set('treblle_streamed_capture', $capture);
 
         $response->setCallback(static function () use ($original, $capture): void {
@@ -178,6 +181,11 @@ final class TreblleMiddleware
                         break; // non-removable buffer; avoid an infinite loop
                     }
                 }
+
+                // Return this stream's reserved bytes to the shared budget. This
+                // runs on normal completion, error, or client abort, so the
+                // budget can never leak — the invariant the whole design relies on.
+                $capture->releaseBudget();
             }
         });
     }

--- a/src/TreblleServiceProvider.php
+++ b/src/TreblleServiceProvider.php
@@ -15,6 +15,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Console\AboutCommand;
 use Treblle\Laravel\Helpers\SensitiveDataMasker;
+use Treblle\Laravel\Helpers\StreamCaptureBudget;
 use Treblle\Laravel\Middlewares\TreblleMiddleware;
 use Treblle\Laravel\Middlewares\TreblleEarlyMiddleware;
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -157,6 +158,13 @@ final class TreblleServiceProvider extends ServiceProvider
         // Scoped binding: one QueryCollector per request, reset automatically
         // under Octane between requests so queries never bleed across requests.
         $this->app->scoped(QueryCollector::class, fn () => new QueryCollector());
+
+        // Singleton stream-capture budget: a process-wide byte counter shared by
+        // all concurrent stream captures so their combined memory stays bounded.
+        // MUST be a singleton (not scoped) so it is shared across the concurrent
+        // requests of one Octane worker; a scoped binding would reset per request
+        // and defeat the aggregate bound.
+        $this->app->singleton(StreamCaptureBudget::class, fn () => new StreamCaptureBudget());
 
         // Persistent Guzzle client: reuses TCP connections and TLS sessions to
         // Treblle's ingress endpoint across requests instead of opening a new

--- a/tests/Feature/DataProviders/LaravelResponseDataProviderTest.php
+++ b/tests/Feature/DataProviders/LaravelResponseDataProviderTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Treblle\Laravel\Tests\TestCase;
 use Treblle\Laravel\Helpers\SensitiveDataMasker;
+use Treblle\Laravel\Helpers\StreamCaptureBudget;
 use Treblle\Laravel\Helpers\StreamedResponseCapture;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Treblle\Laravel\DataProviders\InMemoryErrorDataProvider;
@@ -260,6 +261,26 @@ final class LaravelResponseDataProviderTest extends TestCase
 
         $this->assertCount(1, $errors);
         $this->assertSame('Streamed response truncated at capture limit', $errors[0]->getMessage());
+    }
+
+    public function test_budget_capped_streamed_capture_reports_memory_budget_reason(): void
+    {
+        $budget = new StreamCaptureBudget(max: 3);
+        $capture = new StreamedResponseCapture(budget: $budget);
+        $capture->append('abcdef'); // 6 bytes > 3 budget → denied, reason memory_budget
+        $request = Request::create('http://localhost/api/stream', 'GET');
+        $request->attributes->set('treblle_streamed_capture', $capture);
+
+        $response = new StreamedResponse(fn () => null, 200, ['Content-Type' => 'text/plain']);
+        $errorProvider = new InMemoryErrorDataProvider();
+
+        $provider = new LaravelResponseDataProvider(new SensitiveDataMasker(), $request, $response, $errorProvider);
+        $provider->getResponse();
+
+        $errors = $errorProvider->getErrors();
+
+        $this->assertCount(1, $errors);
+        $this->assertSame('Streamed response body not fully captured (memory budget reached)', $errors[0]->getMessage());
     }
 
     public function test_404_response_preserves_status_code(): void

--- a/tests/Feature/DataProviders/LaravelResponseDataProviderTest.php
+++ b/tests/Feature/DataProviders/LaravelResponseDataProviderTest.php
@@ -8,6 +8,8 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Treblle\Laravel\Tests\TestCase;
 use Treblle\Laravel\Helpers\SensitiveDataMasker;
+use Treblle\Laravel\Helpers\StreamedResponseCapture;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Treblle\Laravel\DataProviders\InMemoryErrorDataProvider;
 use Treblle\Laravel\DataProviders\LaravelResponseDataProvider;
 
@@ -158,6 +160,106 @@ final class LaravelResponseDataProviderTest extends TestCase
         if (null !== $savedRequestTimeFloat) {
             $_SERVER['REQUEST_TIME_FLOAT'] = $savedRequestTimeFloat;
         }
+    }
+
+    public function test_streamed_sse_response_body_is_parsed_into_events(): void
+    {
+        $request = Request::create('http://localhost/api/stream', 'GET');
+        $capture = new StreamedResponseCapture();
+        $capture->append("event: greeting\ndata: {\"msg\":\"hello\"}\n\nevent: farewell\ndata: bye\n\n");
+        $request->attributes->set('treblle_streamed_capture', $capture);
+
+        $response = new StreamedResponse(fn () => null, 200, ['Content-Type' => 'text/event-stream']);
+        $errorProvider = new InMemoryErrorDataProvider();
+
+        $provider = new LaravelResponseDataProvider(new SensitiveDataMasker(), $request, $response, $errorProvider);
+        $serialized = $provider->getResponse()->jsonSerialize();
+
+        $this->assertCount(2, $serialized['body']);
+        $this->assertSame('greeting', $serialized['body'][0]['event']);
+        $this->assertSame(['msg' => 'hello'], $serialized['body'][0]['data']);
+        $this->assertSame('bye', $serialized['body'][1]['data']);
+        $this->assertSame((float) strlen($capture->getContent()), $serialized['size']);
+    }
+
+    public function test_streamed_json_response_body_is_decoded(): void
+    {
+        $request = Request::create('http://localhost/api/stream', 'GET');
+        $capture = new StreamedResponseCapture();
+        $capture->append('{"users":[{"id":1},{"id":2}]}');
+        $request->attributes->set('treblle_streamed_capture', $capture);
+
+        $response = new StreamedResponse(fn () => null, 200, ['Content-Type' => 'application/json']);
+        $errorProvider = new InMemoryErrorDataProvider();
+
+        $provider = new LaravelResponseDataProvider(new SensitiveDataMasker(), $request, $response, $errorProvider);
+        $serialized = $provider->getResponse()->jsonSerialize();
+
+        $this->assertSame([['id' => 1], ['id' => 2]], $serialized['body']['users']);
+    }
+
+    public function test_generic_stream_non_json_body_falls_back_to_raw(): void
+    {
+        $request = Request::create('http://localhost/api/stream', 'GET');
+        $capture = new StreamedResponseCapture();
+        $capture->append('plain streamed text');
+        $request->attributes->set('treblle_streamed_capture', $capture);
+
+        $response = new StreamedResponse(fn () => null, 200, ['Content-Type' => 'text/plain']);
+        $errorProvider = new InMemoryErrorDataProvider();
+
+        $provider = new LaravelResponseDataProvider(new SensitiveDataMasker(), $request, $response, $errorProvider);
+        $serialized = $provider->getResponse()->jsonSerialize();
+
+        $this->assertSame('plain streamed text', $serialized['body']['raw']);
+    }
+
+    public function test_streamed_response_without_capture_is_empty_body(): void
+    {
+        $request = Request::create('http://localhost/api/stream', 'GET');
+        $response = new StreamedResponse(fn () => null, 200, ['Content-Type' => 'text/event-stream']);
+        $errorProvider = new InMemoryErrorDataProvider();
+
+        $provider = new LaravelResponseDataProvider(new SensitiveDataMasker(), $request, $response, $errorProvider);
+        $serialized = $provider->getResponse()->jsonSerialize();
+
+        $this->assertSame([], $serialized['body']);
+    }
+
+    public function test_streamed_sse_masks_sensitive_data_fields(): void
+    {
+        $request = Request::create('http://localhost/api/stream', 'GET');
+        $capture = new StreamedResponseCapture();
+        $capture->append("data: {\"api_key\":\"secret-value\"}\n\n");
+        $request->attributes->set('treblle_streamed_capture', $capture);
+
+        $response = new StreamedResponse(fn () => null, 200, ['Content-Type' => 'text/event-stream']);
+        $masker = new SensitiveDataMasker(['api_key']);
+        $errorProvider = new InMemoryErrorDataProvider();
+
+        $provider = new LaravelResponseDataProvider($masker, $request, $response, $errorProvider);
+        $serialized = $provider->getResponse()->jsonSerialize();
+
+        $this->assertSame(str_repeat('*', mb_strlen('secret-value')), $serialized['body'][0]['data']['api_key']);
+    }
+
+    public function test_truncated_streamed_capture_adds_error(): void
+    {
+        $request = Request::create('http://localhost/api/stream', 'GET');
+        $capture = new StreamedResponseCapture(limit: 10);
+        $capture->append(str_repeat('x', 50)); // exceeds the 10 byte limit
+        $request->attributes->set('treblle_streamed_capture', $capture);
+
+        $response = new StreamedResponse(fn () => null, 200, ['Content-Type' => 'text/plain']);
+        $errorProvider = new InMemoryErrorDataProvider();
+
+        $provider = new LaravelResponseDataProvider(new SensitiveDataMasker(), $request, $response, $errorProvider);
+        $provider->getResponse();
+
+        $errors = $errorProvider->getErrors();
+
+        $this->assertCount(1, $errors);
+        $this->assertSame('Streamed response truncated at capture limit', $errors[0]->getMessage());
     }
 
     public function test_404_response_preserves_status_code(): void

--- a/tests/Feature/Middlewares/TreblleMiddlewareTest.php
+++ b/tests/Feature/Middlewares/TreblleMiddlewareTest.php
@@ -336,6 +336,59 @@ final class TreblleMiddlewareTest extends TestCase
         $this->assertSame('chunk1chunk2', $this->lastTrebllePayload()['data']['response']['body']['raw']);
     }
 
+    public function test_capture_flushes_buffer_left_open_by_callback(): void
+    {
+        $request = Request::create('http://localhost/api/stream', 'GET');
+
+        $response = (new TreblleMiddleware())->handle(
+            $request,
+            fn () => new StreamedResponse(function (): void {
+                echo 'before';
+                ob_start(); // callback opens its own buffer and never closes it
+                echo 'inside';
+            }, 200, ['Content-Type' => 'text/plain']),
+        );
+
+        $outerLevel = ob_get_level();
+
+        ob_start();
+        $response->sendContent();
+        $clientOutput = ob_get_clean();
+
+        // The wrapper unwound its own buffer and the one the callback leaked,
+        // restoring the buffer depth and flushing all content through.
+        $this->assertSame($outerLevel, ob_get_level());
+        $this->assertSame('beforeinside', $clientOutput);
+        $this->assertSame('beforeinside', $request->attributes->get('treblle_streamed_capture')->getContent());
+    }
+
+    public function test_capture_does_not_close_preexisting_buffers(): void
+    {
+        $request = Request::create('http://localhost/api/stream', 'GET');
+
+        $response = (new TreblleMiddleware())->handle(
+            $request,
+            // Callback that tears down exactly the wrapper's own buffer, leaving
+            // the buffer that existed beneath it intact.
+            fn () => new StreamedResponse(function (): void {
+                echo 'x';
+                ob_end_flush();
+            }, 200, ['Content-Type' => 'text/plain']),
+        );
+
+        // A framework-style buffer that existed before the wrapper ran.
+        ob_start();
+        $preexistingLevel = ob_get_level();
+
+        $response->sendContent();
+
+        // The callback already closed the wrapper's buffer; the wrapper's finally
+        // must NOT go on to close the pre-existing buffer beneath it.
+        $this->assertSame($preexistingLevel, ob_get_level());
+
+        ob_end_clean();
+    }
+
     /**
      * Decode the gzip-compressed JSON payload sent to the Treblle ingress.
      *

--- a/tests/Feature/Middlewares/TreblleMiddlewareTest.php
+++ b/tests/Feature/Middlewares/TreblleMiddlewareTest.php
@@ -13,6 +13,8 @@ use Treblle\Laravel\Tests\TestCase;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\Request as GuzzlePsr7Request;
 use Treblle\Laravel\Middlewares\TreblleMiddleware;
+use Treblle\Laravel\Helpers\StreamedResponseCapture;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 final class TreblleMiddlewareTest extends TestCase
 {
@@ -216,5 +218,134 @@ final class TreblleMiddlewareTest extends TestCase
         $result  = (new TreblleMiddleware())->handle($request, fn ($req) => new Response('ok', 200));
 
         $this->assertSame(200, $result->getStatusCode());
+    }
+
+    public function test_wraps_streamed_response_and_tees_output_to_capture(): void
+    {
+        $sse = "event: message\ndata: {\"token\":\"hi\"}\n\n";
+        $request = Request::create('http://localhost/api/stream', 'GET');
+
+        $response = (new TreblleMiddleware())->handle(
+            $request,
+            fn () => new StreamedResponse(function () use ($sse): void {
+                echo $sse;
+            }, 200, ['Content-Type' => 'text/event-stream']),
+        );
+
+        // Simulate Laravel sending the streamed body to the client.
+        ob_start();
+        $response->sendContent();
+        $clientOutput = ob_get_clean();
+
+        // The client still receives the streamed bytes unchanged...
+        $this->assertSame($sse, $clientOutput);
+
+        // ...and Treblle captured a copy for the payload.
+        $capture = $request->attributes->get('treblle_streamed_capture');
+        $this->assertInstanceOf(StreamedResponseCapture::class, $capture);
+        $this->assertSame($sse, $capture->getContent());
+    }
+
+    public function test_does_not_wrap_non_streamed_responses(): void
+    {
+        $request = Request::create('http://localhost/api/test', 'GET');
+
+        (new TreblleMiddleware())->handle($request, fn () => new Response('ok', 200));
+
+        $this->assertNull($request->attributes->get('treblle_streamed_capture'));
+    }
+
+    public function test_streamed_sse_body_reaches_treblle_as_events(): void
+    {
+        $sse = "event: greeting\ndata: {\"msg\":\"hello\"}\n\n";
+        $request = Request::create('http://localhost/api/stream', 'GET');
+        $middleware = new TreblleMiddleware();
+
+        $response = $middleware->handle(
+            $request,
+            fn () => new StreamedResponse(function () use ($sse): void {
+                echo $sse;
+            }, 200, ['Content-Type' => 'text/event-stream']),
+        );
+
+        ob_start();
+        $response->sendContent();
+        ob_end_clean();
+
+        $middleware->terminate($request, $response);
+
+        $this->assertTreblleRequestSent();
+        $payload = $this->lastTrebllePayload();
+        $events = $payload['data']['response']['body'];
+
+        $this->assertSame('greeting', $events[0]['event']);
+        $this->assertSame(['msg' => 'hello'], $events[0]['data']);
+    }
+
+    public function test_real_event_stream_helper_is_captured_and_parsed(): void
+    {
+        // Exercises Laravel's response()->eventStream() including its internal
+        // ob_flush()/flush() calls composed with our capture buffer, in the
+        // real HTTP order: handle() -> sendContent() -> terminate().
+        $request = Request::create('http://localhost/api/chat', 'GET');
+        $middleware = new TreblleMiddleware();
+
+        $response = $middleware->handle($request, fn () => response()->eventStream(function () {
+            yield 'Hello';
+            yield ['token' => 'world'];
+        }));
+
+        ob_start();
+        $response->sendContent();
+        ob_end_clean();
+
+        $capture = $request->attributes->get('treblle_streamed_capture');
+        $this->assertInstanceOf(StreamedResponseCapture::class, $capture);
+        $this->assertStringContainsString('data: Hello', $capture->getContent());
+
+        $middleware->terminate($request, $response);
+
+        $this->assertTreblleRequestSent();
+        $events = $this->lastTrebllePayload()['data']['response']['body'];
+        $data = array_column($events, 'data');
+
+        $this->assertContains('Hello', $data);
+        $this->assertContains(['token' => 'world'], $data);
+    }
+
+    public function test_real_stream_helper_is_captured_as_raw(): void
+    {
+        $request = Request::create('http://localhost/api/download', 'GET');
+        $middleware = new TreblleMiddleware();
+
+        $response = $middleware->handle($request, fn () => response()->stream(function (): void {
+            echo 'chunk1';
+            echo 'chunk2';
+        }, 200, ['Content-Type' => 'text/plain']));
+
+        ob_start();
+        $response->sendContent();
+        ob_end_clean();
+
+        $capture = $request->attributes->get('treblle_streamed_capture');
+        $this->assertInstanceOf(StreamedResponseCapture::class, $capture);
+        $this->assertSame('chunk1chunk2', $capture->getContent());
+
+        $middleware->terminate($request, $response);
+
+        $this->assertSame('chunk1chunk2', $this->lastTrebllePayload()['data']['response']['body']['raw']);
+    }
+
+    /**
+     * Decode the gzip-compressed JSON payload sent to the Treblle ingress.
+     *
+     * @return array<string, mixed>
+     */
+    private function lastTrebllePayload(): array
+    {
+        /** @var \Psr\Http\Message\RequestInterface $request */
+        $request = $this->treblleSentRequests[0]['request'];
+
+        return json_decode((string) gzdecode((string) $request->getBody()), true);
     }
 }

--- a/tests/Feature/Middlewares/TreblleMiddlewareTest.php
+++ b/tests/Feature/Middlewares/TreblleMiddlewareTest.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Response;
 use GuzzleHttp\Handler\MockHandler;
 use Treblle\Laravel\Tests\TestCase;
 use GuzzleHttp\Exception\ConnectException;
+use Treblle\Laravel\Helpers\StreamCaptureBudget;
 use GuzzleHttp\Psr7\Request as GuzzlePsr7Request;
 use Treblle\Laravel\Middlewares\TreblleMiddleware;
 use Treblle\Laravel\Helpers\StreamedResponseCapture;
@@ -253,6 +254,60 @@ final class TreblleMiddlewareTest extends TestCase
         (new TreblleMiddleware())->handle($request, fn () => new Response('ok', 200));
 
         $this->assertNull($request->attributes->get('treblle_streamed_capture'));
+    }
+
+    public function test_stream_capture_releases_its_budget_after_sending(): void
+    {
+        // Real wiring: the wrapped callback reserves from the shared budget as it
+        // streams and releases in its finally, so used() is back to 0 afterwards.
+        $budget = new StreamCaptureBudget(max: 1024);
+        $this->app->instance(StreamCaptureBudget::class, $budget);
+
+        $request = Request::create('http://localhost/api/stream', 'GET');
+
+        $response = (new TreblleMiddleware())->handle(
+            $request,
+            fn () => new StreamedResponse(function (): void {
+                echo 'chunk';
+            }, 200, ['Content-Type' => 'text/plain']),
+        );
+
+        ob_start();
+        $response->sendContent();
+        ob_end_clean();
+
+        $this->assertSame('chunk', $request->attributes->get('treblle_streamed_capture')->getContent());
+        $this->assertSame(0, $budget->used()); // released in the finally — no leak
+    }
+
+    public function test_over_budget_stream_is_monitored_without_a_body(): void
+    {
+        // A tiny shared budget that is already full: the stream still streams to
+        // the client, but its body is not captured and the reason is recorded.
+        $budget = new StreamCaptureBudget(max: 4);
+        $budget->tryReserve(4); // pre-fill: no headroom left
+        $this->app->instance(StreamCaptureBudget::class, $budget);
+
+        $request = Request::create('http://localhost/api/stream', 'GET');
+
+        $response = (new TreblleMiddleware())->handle(
+            $request,
+            fn () => new StreamedResponse(function (): void {
+                echo 'hello world';
+            }, 200, ['Content-Type' => 'text/plain']),
+        );
+
+        ob_start();
+        $response->sendContent();
+        $clientOutput = ob_get_clean();
+
+        // Client still gets the full stream...
+        $this->assertSame('hello world', $clientOutput);
+
+        // ...but Treblle captured no body and flagged why.
+        $capture = $request->attributes->get('treblle_streamed_capture');
+        $this->assertSame('', $capture->getContent());
+        $this->assertSame('memory_budget', $capture->reason());
     }
 
     public function test_streamed_sse_body_reaches_treblle_as_events(): void

--- a/tests/Unit/Helpers/EventStreamParserTest.php
+++ b/tests/Unit/Helpers/EventStreamParserTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\Tests\Unit\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use Treblle\Laravel\Helpers\EventStreamParser;
+
+final class EventStreamParserTest extends TestCase
+{
+    public function test_returns_empty_array_for_blank_input(): void
+    {
+        $this->assertSame([], EventStreamParser::parse(''));
+        $this->assertSame([], EventStreamParser::parse("\n\n"));
+    }
+
+    public function test_parses_a_single_event_with_json_data(): void
+    {
+        $raw = "event: message\ndata: {\"token\":\"hi\"}\n\n";
+
+        $events = EventStreamParser::parse($raw);
+
+        $this->assertCount(1, $events);
+        $this->assertSame('message', $events[0]['event']);
+        $this->assertSame(['token' => 'hi'], $events[0]['data']);
+    }
+
+    public function test_parses_multiple_events(): void
+    {
+        $raw = "id: 1\nevent: greeting\ndata: hello\n\nid: 2\nevent: farewell\ndata: bye\n\n";
+
+        $events = EventStreamParser::parse($raw);
+
+        $this->assertCount(2, $events);
+        $this->assertSame('1', $events[0]['id']);
+        $this->assertSame('greeting', $events[0]['event']);
+        $this->assertSame('hello', $events[0]['data']);
+        $this->assertSame('2', $events[1]['id']);
+        $this->assertSame('farewell', $events[1]['event']);
+        $this->assertSame('bye', $events[1]['data']);
+    }
+
+    public function test_joins_multiline_data_with_newline(): void
+    {
+        $raw = "data: line one\ndata: line two\n\n";
+
+        $events = EventStreamParser::parse($raw);
+
+        $this->assertSame("line one\nline two", $events[0]['data']);
+    }
+
+    public function test_keeps_non_json_data_as_string(): void
+    {
+        $raw = "data: </stream>\n\n";
+
+        $events = EventStreamParser::parse($raw);
+
+        $this->assertSame('</stream>', $events[0]['data']);
+    }
+
+    public function test_ignores_comment_lines(): void
+    {
+        $raw = ": this is a keep-alive comment\ndata: payload\n\n";
+
+        $events = EventStreamParser::parse($raw);
+
+        $this->assertCount(1, $events);
+        $this->assertSame('payload', $events[0]['data']);
+    }
+
+    public function test_parses_retry_as_integer(): void
+    {
+        $raw = "retry: 3000\ndata: x\n\n";
+
+        $events = EventStreamParser::parse($raw);
+
+        $this->assertSame(3000, $events[0]['retry']);
+    }
+
+    public function test_handles_crlf_line_endings(): void
+    {
+        $raw = "event: message\r\ndata: hi\r\n\r\n";
+
+        $events = EventStreamParser::parse($raw);
+
+        $this->assertCount(1, $events);
+        $this->assertSame('message', $events[0]['event']);
+        $this->assertSame('hi', $events[0]['data']);
+    }
+
+    public function test_strips_only_a_single_leading_space_after_colon(): void
+    {
+        $raw = "data:  two-leading-spaces\n\n";
+
+        $events = EventStreamParser::parse($raw);
+
+        $this->assertSame(' two-leading-spaces', $events[0]['data']);
+    }
+}

--- a/tests/Unit/Helpers/StreamCaptureBudgetTest.php
+++ b/tests/Unit/Helpers/StreamCaptureBudgetTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\Tests\Unit\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use Treblle\Laravel\Helpers\StreamCaptureBudget;
+
+final class StreamCaptureBudgetTest extends TestCase
+{
+    public function test_reserves_within_the_limit(): void
+    {
+        $budget = new StreamCaptureBudget(max: 100);
+
+        $this->assertTrue($budget->tryReserve(40));
+        $this->assertTrue($budget->tryReserve(60));
+        $this->assertSame(100, $budget->used());
+    }
+
+    public function test_denies_a_reservation_that_would_exceed_the_limit(): void
+    {
+        $budget = new StreamCaptureBudget(max: 100);
+        $budget->tryReserve(90);
+
+        $this->assertFalse($budget->tryReserve(20));
+        // A denied reservation must not change the counter.
+        $this->assertSame(90, $budget->used());
+    }
+
+    public function test_release_frees_capacity(): void
+    {
+        $budget = new StreamCaptureBudget(max: 100);
+        $budget->tryReserve(100);
+
+        $this->assertFalse($budget->tryReserve(1));
+
+        $budget->release(50);
+
+        $this->assertSame(50, $budget->used());
+        $this->assertTrue($budget->tryReserve(50));
+    }
+
+    public function test_release_floors_at_zero(): void
+    {
+        $budget = new StreamCaptureBudget(max: 100);
+        $budget->tryReserve(10);
+
+        $budget->release(999);
+
+        $this->assertSame(0, $budget->used());
+    }
+
+    public function test_default_ceiling_is_the_hardcoded_constant(): void
+    {
+        $budget = new StreamCaptureBudget();
+
+        $this->assertTrue($budget->tryReserve(StreamCaptureBudget::MAX));
+        $this->assertFalse($budget->tryReserve(1));
+    }
+}

--- a/tests/Unit/Helpers/StreamedResponseCaptureTest.php
+++ b/tests/Unit/Helpers/StreamedResponseCaptureTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Treblle\Laravel\Tests\Unit\Helpers;
 
 use PHPUnit\Framework\TestCase;
+use Treblle\Laravel\Helpers\StreamCaptureBudget;
 use Treblle\Laravel\Helpers\StreamedResponseCapture;
 
 final class StreamedResponseCaptureTest extends TestCase
@@ -37,5 +38,93 @@ final class StreamedResponseCaptureTest extends TestCase
 
         $this->assertSame('ab', $capture->getContent());
         $this->assertTrue($capture->isTruncated());
+    }
+
+    public function test_reserves_from_and_releases_to_the_budget_on_the_happy_path(): void
+    {
+        $budget = new StreamCaptureBudget(max: 100);
+        $capture = new StreamedResponseCapture(budget: $budget);
+
+        $capture->append('hello'); // 5 bytes
+        $this->assertSame(5, $budget->used());
+        $this->assertNull($capture->reason());
+
+        $capture->releaseBudget();
+        $this->assertSame(0, $budget->used()); // baseline restored
+    }
+
+    public function test_stops_capturing_when_the_budget_is_exhausted(): void
+    {
+        $budget = new StreamCaptureBudget(max: 4);
+        $capture = new StreamedResponseCapture(budget: $budget);
+
+        $capture->append('abcdef'); // 6 bytes > 4 budget → denied entirely
+
+        $this->assertSame('', $capture->getContent());
+        $this->assertTrue($capture->isTruncated());
+        $this->assertSame('memory_budget', $capture->reason());
+        $this->assertSame(0, $budget->used()); // nothing was reserved
+
+        $capture->releaseBudget();
+        $this->assertSame(0, $budget->used()); // baseline restored
+    }
+
+    public function test_partial_capture_then_budget_denial_keeps_reservation_symmetric(): void
+    {
+        $budget = new StreamCaptureBudget(max: 8);
+        $capture = new StreamedResponseCapture(budget: $budget);
+
+        $capture->append('abcde'); // 5 bytes reserved
+        $capture->append('xyz1234'); // 7 bytes: 5 + 7 > 8 → denied, stops here
+
+        $this->assertSame('abcde', $capture->getContent());
+        $this->assertTrue($capture->isTruncated());
+        $this->assertSame('memory_budget', $capture->reason());
+        $this->assertSame(5, $budget->used()); // only the kept bytes are reserved
+
+        $capture->releaseBudget();
+        $this->assertSame(0, $budget->used()); // baseline restored — no drift
+    }
+
+    public function test_stream_limit_truncation_reserves_only_kept_bytes(): void
+    {
+        // The per-stream 2MB cap shortens the chunk; the budget must be charged
+        // the shortened size, not the original — otherwise used/reserved diverge.
+        $budget = new StreamCaptureBudget(max: 100);
+        $capture = new StreamedResponseCapture(limit: 3, budget: $budget);
+
+        $capture->append('abcdefghij'); // only 'abc' fits the 3 byte stream limit
+
+        $this->assertSame('abc', $capture->getContent());
+        $this->assertTrue($capture->isTruncated());
+        $this->assertSame('stream_limit', $capture->reason());
+        $this->assertSame(3, $budget->used()); // charged 3, not 10
+
+        $capture->releaseBudget();
+        $this->assertSame(0, $budget->used()); // baseline restored
+    }
+
+    public function test_two_streams_share_one_budget(): void
+    {
+        $budget = new StreamCaptureBudget(max: 6);
+
+        $first = new StreamedResponseCapture(budget: $budget);
+        $first->append('abcdef'); // fills the budget (6/6)
+        $this->assertSame('abcdef', $first->getContent());
+
+        $second = new StreamedResponseCapture(budget: $budget);
+        $second->append('x'); // no room left → denied, monitored without a body
+        $this->assertSame('', $second->getContent());
+        $this->assertSame('memory_budget', $second->reason());
+
+        // After the first stream ends, its budget frees up...
+        $first->releaseBudget();
+        $this->assertSame(0, $budget->used());
+
+        // ...so a subsequent stream captures normally again — proving no leak.
+        $third = new StreamedResponseCapture(budget: $budget);
+        $third->append('yz');
+        $this->assertSame('yz', $third->getContent());
+        $this->assertFalse($third->isTruncated());
     }
 }

--- a/tests/Unit/Helpers/StreamedResponseCaptureTest.php
+++ b/tests/Unit/Helpers/StreamedResponseCaptureTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Treblle\Laravel\Tests\Unit\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use Treblle\Laravel\Helpers\StreamedResponseCapture;
+
+final class StreamedResponseCaptureTest extends TestCase
+{
+    public function test_accumulates_appended_chunks(): void
+    {
+        $capture = new StreamedResponseCapture();
+        $capture->append('foo');
+        $capture->append('bar');
+
+        $this->assertSame('foobar', $capture->getContent());
+        $this->assertFalse($capture->isTruncated());
+    }
+
+    public function test_caps_content_at_limit_and_flags_truncation(): void
+    {
+        $capture = new StreamedResponseCapture(limit: 5);
+        $capture->append('abc');
+        $capture->append('defgh'); // only 'de' fits within the 5 byte limit
+
+        $this->assertSame('abcde', $capture->getContent());
+        $this->assertTrue($capture->isTruncated());
+    }
+
+    public function test_drops_chunks_after_truncation(): void
+    {
+        $capture = new StreamedResponseCapture(limit: 2);
+        $capture->append('abcd');
+        $capture->append('more');
+
+        $this->assertSame('ab', $capture->getContent());
+        $this->assertTrue($capture->isTruncated());
+    }
+}


### PR DESCRIPTION
Treblle now captures streamed responses - `response()->stream()`, `response()->eventStream()` (SSE), and `response()->streamJson()`. Previously these reported an empty body, because a `StreamedResponse` generates its body from a callback during send, so `getContent() `returns `false`.

The middleware wraps the streamed callback in a pass-through output buffer that tees each chunk into a capture holder as it flows to the client, then reads it in `terminate()`. Since we can't stream events to the ingress, we collect the full body and send it once, after the stream closes.

- Real-time delivery is preserved - `chunk_size`: 1 flushes each write immediately, so clients still receive chunks incrementally. The tee only copies bytes.
- SSE bodies are parsed into structured events (id / event / retry / data), with data JSON-decoded when valid. Sensitive-field masking still applies.
- Memory is bounded - a 2MB per-stream cap plus a process-wide 32MB budget shared across concurrent streams (a singleton, so it holds under Octane). Past either limit, capture stops but streaming to the client is unaffected and the truncation is recorded as an error on the request.
- Zero overhead on non-streamed responses - guarded by a single instanceof `StreamedResponse` check.
